### PR TITLE
fix: 徹底解決菜單刪除後品項復活問題

### DIFF
--- a/src/firebase/menu.js
+++ b/src/firebase/menu.js
@@ -17,8 +17,10 @@ import {
   collection,
   doc,
   getDocs,
+  getDocsFromServer,
   setDoc,
   deleteDoc,
+  waitForPendingWrites,
 } from "firebase/firestore";
 import { db } from "./config";
 
@@ -26,16 +28,18 @@ const STORE_ID = "default_store";
 
 /**
  * 取得選單資料
- * @returns {Array|null} 選單項目陣列，失敗時返回 null
+ * @returns {Array|null}
+ *   - Array（可能是空陣列）：成功讀取，Firebase 實際有幾個品項就回幾個
+ *   - null：讀取失敗（網路錯誤等）
+ *
+ * 注意：空陣列和 null 意義不同
+ * - [] 代表 Firebase 確實沒有菜單（全部刪光的合法狀態）
+ * - null 代表連線失敗，呼叫方需要改用 localStorage 備份做 fallback
  */
 export const getMenuData = async () => {
   try {
     const menuRef = collection(db, "stores", STORE_ID, "menu");
     const menuSnap = await getDocs(menuRef);
-
-    if (menuSnap.empty) {
-      return null;
-    }
 
     const menuItems = [];
     menuSnap.forEach((doc) => {
@@ -161,11 +165,85 @@ export const saveMenuData = async (menuData) => {
     console.log(`🗑️ 刪除結果: ${deleteSuccess}/${deletePromises.length} 成功`);
   }
 
+  // ==================== 步驟 4.5: 從伺服器驗證實際狀態 ====================
+  //
+  // 為什麼需要這一步：
+  // config.js 啟用了 persistentLocalCache，這會讓 setDoc/deleteDoc 的 promise
+  // 在「寫入本地快取」時就 resolve，不等伺服器確認。如果伺服器後來沒真正收到，
+  // 前面的 Promise.allSettled 會全部顯示 success，但 Firebase 遠端其實狀態不對。
+  //
+  // 解法：
+  // 1. waitForPendingWrites：等所有 queue 中的寫入實際送到伺服器
+  // 2. getDocsFromServer：強制從伺服器（而非快取）讀取當前狀態
+  // 3. 比對：應該留下的、應該刪除的，跟伺服器實際狀態是否一致
+  //
+  // 如果離線或網路不穩，waitForPendingWrites 會卡住，所以加 10 秒 timeout：
+  // timeout 時不視為失敗（寫入仍在 queue、上線後會同步），但會 console 警告。
+  let verificationIssues = [];
+  let verificationSkipped = false;
+
+  try {
+    const waitPromise = waitForPendingWrites(db).then(() => ({ synced: true }));
+    const timeoutPromise = new Promise((resolve) =>
+      setTimeout(() => resolve({ synced: false }), 10000),
+    );
+    const waitResult = await Promise.race([waitPromise, timeoutPromise]);
+
+    if (!waitResult.synced) {
+      verificationSkipped = true;
+      console.warn(
+        "⚠️ 寫入尚未完全同步到伺服器（可能網路不穩），跳過驗證。上線後 Firestore 會自動補送寫入。",
+      );
+    } else {
+      const serverSnap = await getDocsFromServer(menuRef);
+      const serverIds = new Set();
+      serverSnap.forEach((d) => serverIds.add(d.id));
+
+      const shouldBeDeletedButStillExist = [];
+      for (const [existingId] of existingItems) {
+        if (!newItemIds.has(existingId) && serverIds.has(existingId)) {
+          shouldBeDeletedButStillExist.push(existingId);
+        }
+      }
+
+      const shouldExistButMissing = [];
+      for (const id of newItemIds) {
+        if (!serverIds.has(id)) {
+          shouldExistButMissing.push(id);
+        }
+      }
+
+      if (shouldBeDeletedButStillExist.length > 0) {
+        verificationIssues.push(
+          `${shouldBeDeletedButStillExist.length} 個品項刪除未生效（伺服器仍有記錄）`,
+        );
+        console.error(
+          "❌ 刪除未生效的品項 ID:",
+          shouldBeDeletedButStillExist,
+        );
+      }
+      if (shouldExistButMissing.length > 0) {
+        verificationIssues.push(
+          `${shouldExistButMissing.length} 個品項寫入未生效（伺服器缺少記錄）`,
+        );
+        console.error("❌ 寫入未生效的品項 ID:", shouldExistButMissing);
+      }
+
+      if (verificationIssues.length === 0) {
+        console.log(`✅ 伺服器驗證通過：${serverIds.size} 個品項狀態一致`);
+      }
+    }
+  } catch (verifyError) {
+    console.warn("⚠️ 伺服器驗證過程失敗（不視為儲存失敗）:", verifyError);
+    verificationSkipped = true;
+  }
+
   // ==================== 步驟 5: 檢查結果 ====================
   const issues = [];
   if (step2Failed) issues.push("無法讀取現有品項清單（刪除操作未執行）");
   if (failCount > 0) issues.push(`${failCount} 個品項更新失敗`);
   if (deleteFailCount > 0) issues.push(`${deleteFailCount} 個品項刪除失敗`);
+  if (verificationIssues.length > 0) issues.push(...verificationIssues);
 
   if (issues.length > 0) {
     const errorMessage = issues.join("、");
@@ -173,7 +251,11 @@ export const saveMenuData = async (menuData) => {
     throw new Error(errorMessage);
   }
 
-  console.log("✅ 選單保存完成");
+  if (verificationSkipped) {
+    console.log("✅ 選單保存完成（未驗證伺服器實際狀態）");
+  } else {
+    console.log("✅ 選單保存完成（已驗證伺服器狀態）");
+  }
 };
 
 /**

--- a/src/firebase/menu.js
+++ b/src/firebase/menu.js
@@ -69,11 +69,13 @@ export const saveMenuData = async (menuData) => {
   console.log("📝 開始安全保存選單數據...");
 
   // ==================== 步驟 1: 備份到 localStorage ====================
+  // 備份用途：Firebase 讀取失敗時的唯讀 fallback（見 useInitialLoad 菜單載入策略）
+  // version 與 useFirebaseSync、useInitialLoad 保持一致（v3_firebase_first）
   try {
     const backup = {
       data: menuData,
       timestamp: new Date().toISOString(),
-      version: "v2_granular",
+      version: "v3_firebase_first",
     };
     localStorage.setItem("cafeMenuData", JSON.stringify(menuData));
     localStorage.setItem("cafeMenuData_backup", JSON.stringify(backup));

--- a/src/hooks/useFirebaseSync.js
+++ b/src/hooks/useFirebaseSync.js
@@ -102,18 +102,19 @@ const useFirebaseSync = ({
 
   // 儲存菜單到 Firebase
   const saveMenuDataToFirebase = async (newMenuData) => {
-    // 先更新本地 state（立即反應）
+    // 先更新本地 state（讓 UI 立刻反應）
     setMenuData(newMenuData);
 
     // 同步更新 localStorage 備份
-    // 重要：若不更新，被刪除的品項下次啟動時會被合併邏輯誤判為「離線新增」而還原
+    // 用途：Firebase 讀取失敗時的唯讀 fallback（見 useInitialLoad 菜單載入策略）
+    // 注意：此備份不會被寫回 Firebase，純粹作為離線狀態下的顯示來源
     try {
       localStorage.setItem(
         "cafeMenuData_backup",
         JSON.stringify({
           data: newMenuData,
           timestamp: new Date().toISOString(),
-          version: "v2_granular",
+          version: "v3_firebase_first",
         }),
       );
     } catch (e) {
@@ -128,7 +129,8 @@ const useFirebaseSync = ({
         "⚠️ 菜單儲存失敗\n\n" +
         "錯誤原因：" + error.message + "\n\n" +
         "品項變更可能未儲存成功。\n" +
-        "請截圖此訊息並通知管理員。"
+        "請重新整理頁面確認菜單狀態，必要時重試此操作。\n\n" +
+        "若多次失敗，請截圖此訊息並通知管理員。"
       );
     }
   };

--- a/src/hooks/useInitialLoad.js
+++ b/src/hooks/useInitialLoad.js
@@ -1,6 +1,4 @@
 import { useState, useEffect } from "react";
-import { collection, doc, setDoc } from "firebase/firestore";
-import { db } from "../firebase/config";
 import {
   getMenuData,
   getTableStates,
@@ -12,18 +10,17 @@ import {
  * useInitialLoad Hook
  *
  * 原始程式碼：定義在 CafePOSSystem.js 的 loadAllData useEffect 與相關輔助函數
- * 功能效果：應用程式啟動時載入所有資料，包含 localStorage 快取、Firebase 資料、菜單合併邏輯
+ * 功能效果：應用程式啟動時載入所有資料，包含 localStorage 快取、Firebase 資料
  * 用途：封裝初始載入邏輯，讓主元件只需讀取 isLoading/loadError 狀態
- * 組件長度：約 230 行
  *
- * 重要說明：
- * - 菜單合併採「精細版逐品項比對」：比較 localStorage 與 Firebase 的 lastUpdated 時間戳，取較新版本
- * - 若本地有 Firebase 沒有的品項（可能是離線新增），會自動同步回 Firebase
- * - loadFromLocalStorage 是離線備用方案，Firebase 載入失敗時才呼叫
- * - getTableStatusFromOrders 僅為 loadFromLocalStorage 服務，將舊格式 orders 轉換成狀態字串
+ * 菜單載入策略（重要）：
+ * - Firebase 為「唯一真實來源」。讀取成功就用 Firebase（即使是空陣列也尊重）
+ * - localStorage 僅在 Firebase 讀取失敗時作為「唯讀 fallback」
+ * - 絕對不把 localStorage 的品項寫回 Firebase（避免被刪除的品項被復活）
+ * - 離線新增的品項由 Firestore SDK 的 persistentLocalCache 負責 queue，上線後自動同步
+ *
+ * loadFromLocalStorage：桌位/訂單/歷史的離線備用方案，Firebase 整體載入失敗時呼叫
  */
-
-const STORE_ID = "default_store";
 
 const useInitialLoad = ({
   dataManager,
@@ -133,152 +130,62 @@ const useInitialLoad = ({
               })(),
         ]);
 
-        // ==================== 3. 精細版菜單合併邏輯 ====================
-        // 步驟 1: 讀取 localStorage 備份
-        let localMenuMap = new Map();
+        // ==================== 3. 菜單載入（Firebase 為唯一真實來源）====================
+        //
+        // 歷史背景：
+        // 之前採「精細版逐品項合併」—— 會比對 localStorage 與 Firebase 的時間戳，
+        // 本地較新就寫回 Firebase。這設計原意是防止資料遺失，但意外造成兩個問題：
+        //   1. 刪除的品項只要 localStorage 有殘留，下次載入就會被「救回來」（殭屍品項）
+        //   2. 每次載入會刷新 localStorage 時間戳，讓它幾乎永遠比 Firebase 新 →
+        //      觸發整份菜單被重寫回 Firebase，製造大量不必要的寫入
+        //
+        // 新策略：
+        //   - Firebase 回傳非 null：以 Firebase 為準（即使空陣列也尊重，不從本地救回）
+        //   - Firebase 回傳 null（讀取失敗）：localStorage 作唯讀 fallback，不寫回
+        //
+        // 離線編輯不會遺失：Firestore SDK 的 persistentLocalCache（config.js）會把
+        // 離線期間的寫入 queue 在 IndexedDB，網路恢復後自動補送，不需要本層額外處理。
+        let finalMenuData = [];
 
-        try {
-          const localBackup = localStorage.getItem("cafeMenuData_backup");
-          if (localBackup) {
-            const parsed = JSON.parse(localBackup);
-            const localMenuData = parsed.data;
+        if (firebaseMenuData !== null) {
+          finalMenuData = Array.isArray(firebaseMenuData)
+            ? [...firebaseMenuData]
+            : [];
+          console.log(`☁️  Firebase 菜單載入: ${finalMenuData.length} 個品項`);
 
-            if (Array.isArray(localMenuData)) {
-              localMenuData.forEach((item) => {
-                if (item && item.id) {
-                  localMenuMap.set(item.id, {
-                    ...item,
-                    _localTimestamp: new Date(parsed.timestamp),
-                  });
-                }
-              });
-              console.log(
-                `📱 找到本地備份: ${localMenuMap.size} 個品項 (${parsed.timestamp})`,
-              );
-            }
-          }
-        } catch (error) {
-          console.warn("⚠️ 本地備份讀取失敗:", error);
-        }
-
-        // 步驟 2: 建立 Firebase 數據的 Map
-        let firebaseMenuMap = new Map();
-
-        if (
-          firebaseMenuData &&
-          Array.isArray(firebaseMenuData) &&
-          firebaseMenuData.length > 0
-        ) {
-          firebaseMenuData.forEach((item) => {
-            if (item && item.id) {
-              firebaseMenuMap.set(item.id, {
-                ...item,
-                _firebaseTimestamp: item.lastUpdated
-                  ? new Date(item.lastUpdated)
-                  : null,
-              });
-            }
-          });
-          console.log(`☁️  找到 Firebase 數據: ${firebaseMenuMap.size} 個品項`);
-        }
-
-        // 步驟 3: 逐個產品合併
-        const mergedMenu = new Map();
-        const needSync = [];
-        let syncReasons = {
-          newerLocal: 0,
-          onlyLocal: 0,
-          noFirebaseTime: 0,
-          useFirebase: 0,
-        };
-
-        // 3.1 處理所有在 localStorage 中的產品
-        for (const [id, localItem] of localMenuMap) {
-          const firebaseItem = firebaseMenuMap.get(id);
-
-          if (!firebaseItem) {
-            const { _localTimestamp, ...cleanItem } = localItem;
-            mergedMenu.set(id, cleanItem);
-            needSync.push(cleanItem);
-            syncReasons.onlyLocal++;
-          } else {
-            const localTime = localItem._localTimestamp;
-            const firebaseTime = firebaseItem._firebaseTimestamp;
-
-            if (!firebaseTime) {
-              const { _localTimestamp, ...cleanItem } = localItem;
-              mergedMenu.set(id, cleanItem);
-              needSync.push(cleanItem);
-              syncReasons.noFirebaseTime++;
-            } else if (localTime > firebaseTime) {
-              const { _localTimestamp, ...cleanItem } = localItem;
-              mergedMenu.set(id, cleanItem);
-              needSync.push(cleanItem);
-              syncReasons.newerLocal++;
-            } else {
-              const { _firebaseTimestamp, ...cleanItem } = firebaseItem;
-              mergedMenu.set(id, cleanItem);
-              syncReasons.useFirebase++;
-            }
-          }
-        }
-
-        // 3.2 處理只在 Firebase 中的產品
-        for (const [id, firebaseItem] of firebaseMenuMap) {
-          if (!localMenuMap.has(id)) {
-            const { _firebaseTimestamp, ...cleanItem } = firebaseItem;
-            mergedMenu.set(id, cleanItem);
-            syncReasons.useFirebase++;
-          }
-        }
-
-        console.log(
-          `📊 菜單合併：本地較新 ${syncReasons.newerLocal}、只在本地 ${syncReasons.onlyLocal}、Firebase 無時間戳 ${syncReasons.noFirebaseTime}、使用 Firebase ${syncReasons.useFirebase}`,
-        );
-
-        // 步驟 4: 同步需要更新的品項回 Firebase
-        if (needSync.length > 0) {
-          console.log(`🔄 需要同步 ${needSync.length} 個產品到 Firebase`);
           try {
-            const syncPromises = needSync.map(async (item) => {
-              const { id, ...itemData } = item;
-              const menuRef = collection(db, "stores", STORE_ID, "menu");
-              return setDoc(
-                doc(menuRef, id),
-                { ...itemData, lastUpdated: new Date().toISOString() },
-                { merge: true },
-              )
-                .then(() => ({ success: true, id, name: item.name }))
-                .catch((error) => ({ success: false, id, name: item.name, error }));
-            });
-
-            const results = await Promise.allSettled(syncPromises);
-            const successCount = results.filter((r) => r.value?.success).length;
-            console.log(`✅ 同步完成: ${successCount}/${needSync.length} 成功`);
-          } catch (syncError) {
-            console.warn("⚠️ 同步過程發生錯誤:", syncError);
+            localStorage.setItem(
+              "cafeMenuData_backup",
+              JSON.stringify({
+                data: finalMenuData,
+                timestamp: new Date().toISOString(),
+                version: "v3_firebase_first",
+              }),
+            );
+          } catch (backupError) {
+            console.warn("⚠️ 更新本地備份失敗（不影響主流程）:", backupError);
+          }
+        } else {
+          console.warn("⚠️ Firebase 菜單讀取失敗，改用 localStorage 唯讀 fallback");
+          try {
+            const localBackup = localStorage.getItem("cafeMenuData_backup");
+            if (localBackup) {
+              const parsed = JSON.parse(localBackup);
+              if (Array.isArray(parsed.data)) {
+                finalMenuData = parsed.data;
+                console.log(
+                  `📱 使用本地備份: ${finalMenuData.length} 個品項 (備份時間 ${parsed.timestamp})`,
+                );
+              }
+            }
+          } catch (fallbackError) {
+            console.error("❌ 本地備份讀取失敗:", fallbackError);
           }
         }
 
-        // 步驟 5: 轉換為陣列並排序
-        const finalMenuData = Array.from(mergedMenu.values());
         finalMenuData.sort((a, b) => (a.order || 0) - (b.order || 0));
         setMenuData(finalMenuData);
         console.log(`✅ 菜單載入完成，共 ${finalMenuData.length} 個品項`);
-
-        // 步驟 6: 更新 localStorage 備份
-        try {
-          localStorage.setItem(
-            "cafeMenuData_backup",
-            JSON.stringify({
-              data: finalMenuData,
-              timestamp: new Date().toISOString(),
-              version: "v2_granular",
-            }),
-          );
-        } catch (backupError) {
-          console.warn("⚠️ 更新本地備份失敗:", backupError);
-        }
 
         // ==================== 4. 設置桌位與外帶資料 ====================
         const loadedTableStates = firebaseTableStates || {};


### PR DESCRIPTION
## 問題描述

客戶回報菜單品項（特別是「外帶」類別）被刪除後，過幾天會整批復活。
前次 `980de82` 的 fix 只 patch 了單一路徑，根本的架構問題未解，因此 bug 反覆發生。

## 根本原因（兩條路徑疊加）

1. **`useInitialLoad` 的合併邏輯會把 localStorage 殘留寫回 Firebase**
   - 步驟 3.1「只在本地 → onlyLocal sync back」會把任何 Firebase 沒有的 localStorage 品項寫回去
   - 步驟 6 每次載入都覆寫 localStorage 備份時間戳，讓 `localTime > firebaseTime` 幾乎永遠成立，觸發整批品項被重寫回 Firebase
   - 結果：刪除的品項只要 localStorage 有殘留就會被「救」回來

2. **Firestore `persistentLocalCache` 下 `deleteDoc` 的 promise 可能靜默成功**
   - Promise 在寫入本地快取時就 resolve，不等伺服器確認
   - 伺服器若因任何原因沒真正收到，前端看到的「刪除成功」其實沒生效

## 修復內容

### `src/hooks/useInitialLoad.js`（重寫菜單載入邏輯）
- **Firebase 為唯一真實來源**：讀取成功就用 Firebase（空陣列也尊重）
- **localStorage 僅作唯讀 fallback**：Firebase 讀取失敗時才用，不寫回
- 砍掉約 80 行「精細版合併邏輯」，換成 ~40 行的 Firebase-first 策略
- 移除相關 imports（`setDoc`、`collection`、`doc`、`STORE_ID`）

### `src/firebase/menu.js`（新增伺服器端驗證）
- `getMenuData`：區分「空集合（`[]`）」與「讀取失敗（`null`）」
- `saveMenuData` 新增步驟 4.5：
  - `waitForPendingWrites(db)` 配 10 秒 timeout 等待離線 queue 送達伺服器
  - `getDocsFromServer(menuRef)` 強制從伺服器（非快取）讀取當前狀態
  - 比對「應刪除」「應存在」的品項跟伺服器實際狀態是否一致
  - 不一致 → throw，上層的 alert 會明確告知客戶
  - 離線時跳過驗證（不視為失敗），等上線自動同步

### `src/hooks/useFirebaseSync.js`（配合調整）
- 更新註解，舊的「防復活」理由已不適用
- 儲存失敗的 alert 訊息加上「請重新整理頁面確認菜單狀態」提示

## 離線行為

不受影響。Firestore SDK 的 `persistentLocalCache` 會自動 queue 離線寫入、上線後補送，不需要應用層額外的本地同步邏輯。

## 風險評估

失去的功能：**離線新增品項 + 本地快取失敗時的自動恢復**
- 發生條件需三個同時成立：離線 + 編輯菜單 + IndexedDB 快取在同步前遺失
- 三條件同時成立的機率極低（咖啡廳有 WiFi、菜單編輯頻率極低、IndexedDB 遺失罕見）
- 發生時的後果：那次編輯要重新做一次（等同於 Fix A 驗證失敗的處置）
- **比現況「品項持續復活」小得多**

## 測試驗證（已完成）

在 preview URL (`sagasu-pos-demo-git-fix-menu-delet-9a2674-dus-projects-263bc4c5.vercel.app`) 跑了三組測試：

### 測試 1：殭屍品項注入（驗證 Fix B）
1. 在 localStorage 注入一個 Firebase 不存在的假品項，`timestamp` 設成 `2099-12-31T23:59:59.000Z`（舊版必觸發復活）
2. 重整頁面
3. 結果：
   - Console: `☁️ Firebase 菜單載入: 68 個品項`（不是 69）
   - **沒有**出現 `🔄 需要同步` 或 `📊 菜單合併：只在本地 1`
   - localStorage 被 Firebase 實際內容覆寫
   - 殭屍完全清除

### 測試 2：新增品項（驗證 Fix A 寫入）
- `📊 更新結果: 69 成功, 0 失敗`
- `✅ 伺服器驗證通過：69 個品項狀態一致`
- `✅ 選單保存完成（已驗證伺服器狀態）`

### 測試 3：刪除品項（驗證 Fix A 刪除）
- `🗑️ 刪除結果: 1/1 成功`
- `✅ 伺服器驗證通過：68 個品項狀態一致`
- `✅ 選單保存完成（已驗證伺服器狀態）`

## Test plan（合併前複查）

- [x] preview URL 殭屍注入測試通過
- [x] preview URL 新增品項 + 伺服器驗證通過
- [x] preview URL 刪除品項 + 伺服器驗證通過
- [x] `npm run build` 成功（+521 Bytes，只有新增驗證邏輯）
- [x] ESLint 無警告
- [ ] 合併後：請客戶打烊時清 iPad 資料 + 重登（讓舊 localStorage 徹底清乾淨）
- [ ] 合併後：請客戶自行再刪一次外帶類別，觀察新版的伺服器驗證訊息

## 後續（非本 PR 範圍）

若 Firebase 還有從前殘留的「外帶」類別 doc，客戶清 iPad 重登後若仍看到，可請客戶自行刪除（新版刪除會伺服器驗證、失敗會明確提示）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)