### PR TITLE
chore: 新增 Firebase Admin SDK 金鑰防護規則

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ out/
 # Claude 專案指令（個人開發設定，不入 repo）
 CLAUDE.md
 
+# Firebase Admin SDK 服務帳戶金鑰（絕對不入 repo）
+service-account*.json
+*-firebase-adminsdk-*.json
+
 # Windows 系統檔案
 Thumbs.db
 


### PR DESCRIPTION
## 變更摘要

即將建立 Firebase 冷備份工具，會用到 Firebase Admin SDK 的 service account JSON。這類金鑰擁有 Firebase 完整存取權限，外洩等同於整個資料庫被接管，所以加入 `.gitignore` 做雙重防護。

## 變更內容

`.gitignore` 新增：
- `service-account*.json`（命名慣例的檔名）
- `*-firebase-adminsdk-*.json`（Firebase 原始下載的檔名）

## 背景

備份工具放在專案外（`Desktop/工具/sagasu-backup/`），理論上金鑰檔不會進入本 repo。加這個規則是防止以下情境：
- 路徑複製錯誤把金鑰拖進 repo
- 未來新增相關功能時誤把金鑰放進 src/

純防禦性變更、不影響任何既有功能。

## Test plan

- [x] `.gitignore` 語法正確
- [x] 不影響既有追蹤檔案

🤖 Generated with [Claude Code](https://claude.com/claude-code)