### PR TITLE
fix: 登入時系統錯誤不再誤顯示為密碼錯誤

### DIFF
--- a/src/firebase/users.js
+++ b/src/firebase/users.js
@@ -46,19 +46,10 @@ const STORE_ID = "default_store";
  * }
  */
 export const getAuthSettings = async () => {
-  try {
-    const authRef = doc(db, "stores", STORE_ID, "settings", "auth");
-    const authSnap = await getDoc(authRef);
+  const authRef = doc(db, "stores", STORE_ID, "settings", "auth");
+  const authSnap = await getDoc(authRef);
 
-    if (authSnap.exists()) {
-      return authSnap.data();
-    } else {
-      return null;
-    }
-  } catch (error) {
-    console.error("取得認證設定失敗:", error);
-    return null;
-  }
+  return authSnap.exists() ? authSnap.data() : null;
 };
 
 /**
@@ -94,22 +85,14 @@ export const setAuthPassword = async (password) => {
  * @returns {boolean} 密碼是否正確
  */
 export const verifyPassword = async (inputPassword) => {
-  try {
-    const authSettings = await getAuthSettings();
-    if (!authSettings) {
-      console.error("❌ 認證設定不存在");
-      return false;
-    }
-
-    const { hashedPassword, salt } = authSettings;
-    const inputHash = hashPassword(inputPassword, salt);
-    const isValid = inputHash === hashedPassword;
-
-    return isValid;
-  } catch (error) {
-    console.error("驗證密碼失敗:", error);
-    return false;
+  const authSettings = await getAuthSettings();
+  if (!authSettings) {
+    throw new Error("認證設定不存在，請先完成系統初始化");
   }
+
+  const { hashedPassword, salt } = authSettings;
+  const inputHash = hashPassword(inputPassword, salt);
+  return inputHash === hashedPassword;
 };
 
 /**


### PR DESCRIPTION
## Summary

- `getAuthSettings` 跟 `verifyPassword` 原本把所有錯誤吞掉回 null/false，導致 Firebase 連線失敗、IDB 損毀等系統問題被 `loginHandler` 誤判為「密碼錯誤」並扣嘗試次數
- `loginHandler.js` 的 `type:"system"` 分支設計上就準備好處理這類錯誤（顯示「系統連線異常」+ Wifi 圖示 + 不扣次數），但下層吞錯誤讓那段成為死碼
- 移除 try/catch fallback 後，真實的密碼錯誤仍走「密碼錯誤」分支，系統錯誤改走「系統異常」分支

## Background

近期客戶遇過清網站資料後輸入正確密碼仍顯示「密碼錯誤」的事件，後續確認是清資料動作沒實際執行（瀏覽器層問題）。但這個事件揭露 — 即使真的撞到 IDB / Firestore 連線問題，現有程式碼會把它誤導成「密碼錯誤」讓客戶白白懷疑自己。本 PR 修正錯誤分類。

## Test plan

- [x] 程式碼 review：呼叫端 `needsPasswordSetup` / `updateSecurityQuestion` / `changeAuthPassword` 都有自己的 try/catch fallback，不受影響
- [x] 正確密碼登入流程不變
- [x] 錯誤密碼仍顯示「密碼錯誤」+ 扣嘗試次數
- [x] DevTools 模擬 Offline 後嘗試登入 → 顯示「系統異常」+ 不扣嘗試次數

🤖 Generated with [Claude Code](https://claude.com/claude-code)