### PR TITLE
[codex] add expense records overview

### DIFF
--- a/src/components/pages/HistoryPage.js
+++ b/src/components/pages/HistoryPage.js
@@ -1,14 +1,19 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import Header from "../UI/Header";
 import useHistoryData from "../../hooks/useHistoryData";
 import {
   getDateRangeText,
   getDailyBreakdown,
+  getMonthRange,
   groupRecordsByTable,
   getPopularItems,
+  getWeekRange,
 } from "../../utils/historyUtils";
 
 import DateSelector from "./HistoryPage/DateSelector";
+import FinancialTabs from "./HistoryPage/FinancialTabs";
+import ExpenseRecordsPage from "./HistoryPage/ExpenseRecordsPage";
+import ProfitOverviewPage from "./HistoryPage/ProfitOverviewPage";
 import StatisticsCards from "./HistoryPage/StatisticsCards";
 import DailyAnalysisTable from "./HistoryPage/DailyAnalysisTable";
 import PopularItemsCard from "./HistoryPage/PopularItemsCard";
@@ -18,6 +23,11 @@ import RefundStatisticsCard from "./HistoryPage/RefundStatisticsCard";
 import DailyOrdersList from "./HistoryPage/DailyOrdersList";
 import WeeklyMonthlyOverview from "./HistoryPage/WeeklyMonthlyOverview";
 import RefundConfirmModal from "./HistoryPage/RefundConfirmModal";
+import {
+  createDemoIncomeRecords,
+  demoCommonExpenseItems,
+  demoExpenseRecords,
+} from "./HistoryPage/demoFinancialData";
 
 /**
  * HistoryPage
@@ -28,6 +38,10 @@ import RefundConfirmModal from "./HistoryPage/RefundConfirmModal";
  * 組件長度：約 80 行
  */
 const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
+  const [activeFinancialTab, setActiveFinancialTab] = useState("income");
+  const [expenseRecords, setExpenseRecords] = useState(demoExpenseRecords);
+  const [commonExpenseItems, setCommonExpenseItems] = useState(demoCommonExpenseItems);
+
   const {
     salesHistory,
     loading,
@@ -46,8 +60,13 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
     handleCancelRefund,
   } = useHistoryData({ onRefundOrder });
 
-  // 衍生資料
-  const allPeriodRecords = salesHistory;
+  const demoIncomeRecords = useMemo(
+    () => createDemoIncomeRecords(selectedDate),
+    [selectedDate],
+  );
+
+  // v0 fallback: 沒有 Firebase 收入資料時，先用範例資料讓收支總覽可預覽。
+  const allPeriodRecords = salesHistory.length > 0 ? salesHistory : demoIncomeRecords;
   const activePeriodRecords = allPeriodRecords.filter((r) => !r.isRefunded);
   const refundedPeriodRecords = allPeriodRecords.filter((r) => r.isRefunded);
   const periodTotal = activePeriodRecords.reduce((sum, r) => sum + r.total, 0);
@@ -59,6 +78,87 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
   const groupedRecords = groupRecordsByTable(displayRecords);
   const dailyBreakdown = viewMode !== "daily" ? getDailyBreakdown(allPeriodRecords) : [];
   const dateRangeText = getDateRangeText(viewMode, selectedDate);
+
+  const filteredExpenseRecords = useMemo(() => {
+    let startDate = selectedDate;
+    let endDate = selectedDate;
+
+    if (viewMode === "weekly") {
+      const range = getWeekRange(selectedDate);
+      startDate = range.start;
+      endDate = range.end;
+    }
+
+    if (viewMode === "monthly") {
+      const range = getMonthRange(selectedDate);
+      startDate = range.start;
+      endDate = range.end;
+    }
+
+    return expenseRecords
+      .filter((record) => record.date >= startDate && record.date <= endDate)
+      .sort((a, b) => b.date.localeCompare(a.date));
+  }, [expenseRecords, selectedDate, viewMode]);
+
+  const periodExpenseTotal = filteredExpenseRecords.reduce(
+    (sum, record) => sum + record.amount,
+    0,
+  );
+
+  const vendorOptions = useMemo(
+    () => [...new Set(filteredExpenseRecords.map((record) => record.vendor))],
+    [filteredExpenseRecords],
+  );
+
+  const materialOptions = useMemo(
+    () => [...new Set(commonExpenseItems.map((item) => item.name))],
+    [commonExpenseItems],
+  );
+
+  const commonVendorOptions = useMemo(
+    () => [...new Set(commonExpenseItems.map((item) => item.vendor))],
+    [commonExpenseItems],
+  );
+
+  const handleAddExpenseRecord = (record) => {
+    setExpenseRecords((currentRecords) => [
+      {
+        ...record,
+        id: `expense-${Date.now()}`,
+      },
+      ...currentRecords,
+    ]);
+  };
+
+  const handleDeleteExpenseRecord = (recordId) => {
+    setExpenseRecords((currentRecords) =>
+      currentRecords.filter((record) => record.id !== recordId),
+    );
+  };
+
+  const handleAddCommonExpenseItem = (item) => {
+    setCommonExpenseItems((currentItems) => [
+      {
+        ...item,
+        id: `common-expense-${Date.now()}`,
+      },
+      ...currentItems,
+    ]);
+  };
+
+  const handleDeleteCommonExpenseItem = (itemId) => {
+    setCommonExpenseItems((currentItems) =>
+      currentItems.filter((item) => item.id !== itemId),
+    );
+  };
+
+  const handleUpdateCommonExpenseItem = (itemId, nextItem) => {
+    setCommonExpenseItems((currentItems) =>
+      currentItems.map((item) =>
+        item.id === itemId ? { ...item, ...nextItem } : item,
+      ),
+    );
+  };
 
   return (
     <div className="min-h-screen bg-parchment">
@@ -77,6 +177,11 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
       />
 
       <div className="p-4 space-y-4">
+        <FinancialTabs
+          activeTab={activeFinancialTab}
+          onTabChange={setActiveFinancialTab}
+        />
+
         <DateSelector
           selectedDate={selectedDate}
           onDateChange={setSelectedDate}
@@ -85,52 +190,84 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
           displayMode={displayMode}
           onDisplayModeChange={setDisplayMode}
           dateRangeText={dateRangeText}
+          showDisplayModeControls={activeFinancialTab === "income"}
         />
 
-        <StatisticsCards
-          orderCount={activePeriodRecords.length}
-          itemCount={periodItemCount}
-          periodTotal={periodTotal}
-          refundedTotal={refundedTotal}
-        />
+        {activeFinancialTab === "income" && (
+          <>
+            <StatisticsCards
+              orderCount={activePeriodRecords.length}
+              itemCount={periodItemCount}
+              periodTotal={periodTotal}
+              refundedTotal={refundedTotal}
+            />
 
-        <DailyAnalysisTable dailyBreakdown={dailyBreakdown} viewMode={viewMode} />
+            <DailyAnalysisTable dailyBreakdown={dailyBreakdown} viewMode={viewMode} />
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <PopularItemsCard popularItems={popularItems} viewMode={viewMode} />
-          <DetailedRecordsCard
-            activePeriodRecords={activePeriodRecords}
-            periodTotal={periodTotal}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <PopularItemsCard popularItems={popularItems} viewMode={viewMode} />
+              <DetailedRecordsCard
+                activePeriodRecords={activePeriodRecords}
+                periodTotal={periodTotal}
+              />
+              <PaymentMethodCard
+                activePeriodRecords={activePeriodRecords}
+                periodTotal={periodTotal}
+              />
+              <RefundStatisticsCard
+                refundedPeriodRecords={refundedPeriodRecords}
+                allPeriodRecords={allPeriodRecords}
+                refundedTotal={refundedTotal}
+              />
+            </div>
+
+            <DailyOrdersList
+              viewMode={viewMode}
+              displayMode={displayMode}
+              displayRecords={displayRecords}
+              groupedRecords={groupedRecords}
+              selectedDate={selectedDate}
+              showRefundedOrders={showRefundedOrders}
+              onShowRefundedChange={setShowRefundedOrders}
+              onRefundClick={handleRefundClick}
+            />
+
+            <WeeklyMonthlyOverview
+              viewMode={viewMode}
+              displayRecords={displayRecords}
+              showRefundedOrders={showRefundedOrders}
+              onShowRefundedChange={setShowRefundedOrders}
+              onRefundClick={handleRefundClick}
+            />
+          </>
+        )}
+
+        {activeFinancialTab === "expense" && (
+          <ExpenseRecordsPage
+            selectedDate={selectedDate}
+            dateRangeText={dateRangeText}
+            expenseRecords={filteredExpenseRecords}
+            vendorOptions={vendorOptions}
+            materialOptions={materialOptions}
+            commonVendorOptions={commonVendorOptions}
+            commonExpenseItems={commonExpenseItems}
+            onAddRecord={handleAddExpenseRecord}
+            onDeleteRecord={handleDeleteExpenseRecord}
+            onAddCommonItem={handleAddCommonExpenseItem}
+            onUpdateCommonItem={handleUpdateCommonExpenseItem}
+            onDeleteCommonItem={handleDeleteCommonExpenseItem}
           />
-          <PaymentMethodCard
-            activePeriodRecords={activePeriodRecords}
-            periodTotal={periodTotal}
-          />
-          <RefundStatisticsCard
-            refundedPeriodRecords={refundedPeriodRecords}
-            allPeriodRecords={allPeriodRecords}
-            refundedTotal={refundedTotal}
-          />
-        </div>
+        )}
 
-        <DailyOrdersList
-          viewMode={viewMode}
-          displayMode={displayMode}
-          displayRecords={displayRecords}
-          groupedRecords={groupedRecords}
-          selectedDate={selectedDate}
-          showRefundedOrders={showRefundedOrders}
-          onShowRefundedChange={setShowRefundedOrders}
-          onRefundClick={handleRefundClick}
-        />
-
-        <WeeklyMonthlyOverview
-          viewMode={viewMode}
-          displayRecords={displayRecords}
-          showRefundedOrders={showRefundedOrders}
-          onShowRefundedChange={setShowRefundedOrders}
-          onRefundClick={handleRefundClick}
-        />
+        {activeFinancialTab === "overview" && (
+          <ProfitOverviewPage
+            incomeTotal={periodTotal}
+            expenseTotal={periodExpenseTotal}
+            orderCount={activePeriodRecords.length}
+            expenseCount={filteredExpenseRecords.length}
+            dateRangeText={dateRangeText}
+          />
+        )}
       </div>
 
       <RefundConfirmModal

--- a/src/components/pages/HistoryPage/CommonExpenseItemsManagerModal.js
+++ b/src/components/pages/HistoryPage/CommonExpenseItemsManagerModal.js
@@ -1,0 +1,244 @@
+import React, { useMemo, useState } from "react";
+import { Check, Pencil, Search, Trash2, X } from "lucide-react";
+
+const formatCurrency = (amount) => `$${amount.toLocaleString("zh-TW")}`;
+
+const blankItem = {
+  name: "",
+  vendor: "",
+  amount: "",
+};
+
+/**
+ * CommonExpenseItemsManagerModal
+ *
+ * 功能效果：用彈出式頁面管理大量常用原材料，支援搜尋、編輯與刪除
+ * 使用範例：<CommonExpenseItemsManagerModal items={items} onUpdateItem={updateItem} />
+ */
+const CommonExpenseItemsManagerModal = ({
+  items,
+  onClose,
+  onUpdateItem,
+  onDeleteItem,
+}) => {
+  const [editingItemId, setEditingItemId] = useState(null);
+  const [editingDraft, setEditingDraft] = useState(blankItem);
+  const [searchText, setSearchText] = useState("");
+
+  const filteredItems = useMemo(() => {
+    const keyword = searchText.trim().toLowerCase();
+    if (!keyword) return items;
+
+    return items.filter((item) =>
+      `${item.name} ${item.vendor}`.toLowerCase().includes(keyword),
+    );
+  }, [items, searchText]);
+
+  const startEditing = (item) => {
+    setEditingItemId(item.id);
+    setEditingDraft({
+      name: item.name,
+      vendor: item.vendor,
+      amount: String(item.amount),
+    });
+  };
+
+  const cancelEditing = () => {
+    setEditingItemId(null);
+    setEditingDraft(blankItem);
+  };
+
+  const handleEditingChange = (field, value) => {
+    setEditingDraft((currentItem) => ({
+      ...currentItem,
+      [field]: value,
+    }));
+  };
+
+  const handleSaveEditing = () => {
+    const amount = Number(editingDraft.amount);
+    if (!editingDraft.name.trim() || !editingDraft.vendor.trim() || amount <= 0) {
+      window.alert("請填寫常用原材料名稱、廠商與大於 0 的價格");
+      return;
+    }
+
+    onUpdateItem(editingItemId, {
+      name: editingDraft.name.trim(),
+      vendor: editingDraft.vendor.trim(),
+      amount,
+    });
+    cancelEditing();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-anthropic-black/40 p-4">
+      <div className="max-h-[86vh] w-full max-w-3xl overflow-hidden rounded-xl bg-ivory shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-warm-cream p-4">
+          <div>
+            <h3 className="text-lg font-bold text-anthropic-black">
+              管理常用清單
+            </h3>
+            <p className="text-sm text-warm-olive">
+              常用項目變多時，可在這裡搜尋、編輯或刪除。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-warm-olive transition-colors hover:bg-parchment hover:text-warm-charcoal"
+            aria-label="關閉常用清單管理"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="border-b border-warm-cream p-4">
+          <label className="relative block">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-warm-stone" />
+            <input
+              type="text"
+              value={searchText}
+              onChange={(event) => setSearchText(event.target.value)}
+              placeholder="搜尋名稱或廠商"
+              className="w-full rounded-lg border border-warm-sand bg-ivory py-2 pl-9 pr-3 focus:border-terracotta focus:outline-none"
+            />
+          </label>
+        </div>
+
+        <div className="max-h-[52vh] overflow-y-auto p-4">
+          {filteredItems.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-warm-sand py-10 text-center text-warm-stone">
+              找不到符合的常用項目
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {filteredItems.map((item) => (
+                <CommonExpenseItemRow
+                  key={item.id}
+                  item={item}
+                  isEditing={editingItemId === item.id}
+                  editingDraft={editingDraft}
+                  onStartEditing={startEditing}
+                  onCancelEditing={cancelEditing}
+                  onEditingChange={handleEditingChange}
+                  onSaveEditing={handleSaveEditing}
+                  onDeleteItem={onDeleteItem}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end border-t border-warm-cream p-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="min-h-[40px] rounded-lg bg-terracotta px-4 py-2 font-medium text-ivory transition-colors hover:bg-terracotta-dark"
+          >
+            完成
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const CommonExpenseItemRow = ({
+  item,
+  isEditing,
+  editingDraft,
+  onStartEditing,
+  onCancelEditing,
+  onEditingChange,
+  onSaveEditing,
+  onDeleteItem,
+}) => {
+  return (
+    <div className="rounded-lg border border-warm-cream bg-parchment p-3">
+      {isEditing ? (
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(220px,1fr)_180px_120px_auto]">
+          <EditField
+            label="名稱"
+            type="text"
+            value={editingDraft.name}
+            onChange={(value) => onEditingChange("name", value)}
+          />
+          <EditField
+            label="廠商"
+            type="text"
+            value={editingDraft.vendor}
+            onChange={(value) => onEditingChange("vendor", value)}
+          />
+          <EditField
+            label="價格"
+            type="number"
+            value={editingDraft.amount}
+            onChange={(value) => onEditingChange("amount", value)}
+          />
+          <div className="flex items-end gap-2">
+            <button
+              type="button"
+              onClick={onSaveEditing}
+              className="inline-flex min-h-[42px] flex-1 items-center justify-center gap-2 rounded-lg bg-terracotta px-3 py-2 text-sm font-medium text-ivory transition-colors hover:bg-terracotta-dark lg:flex-none"
+            >
+              <Check className="h-4 w-4" />
+              儲存
+            </button>
+            <button
+              type="button"
+              onClick={onCancelEditing}
+              className="inline-flex min-h-[42px] flex-1 items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-warm-olive transition-colors hover:bg-warm-sand lg:flex-none"
+            >
+              取消
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <div className="font-bold text-anthropic-black">{item.name}</div>
+            <div className="mt-1 text-sm text-warm-olive">
+              {item.vendor} · {formatCurrency(item.amount)}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => onStartEditing(item)}
+              className="inline-flex min-h-[38px] flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-warm-charcoal transition-colors hover:bg-warm-sand sm:flex-none"
+            >
+              <Pencil className="h-4 w-4" />
+              編輯
+            </button>
+            <button
+              type="button"
+              onClick={() => onDeleteItem(item.id)}
+              className="inline-flex min-h-[38px] flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-error-warm transition-colors hover:bg-error-warm/10 sm:flex-none"
+            >
+              <Trash2 className="h-4 w-4" />
+              刪除
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const EditField = ({ label, type, value, onChange }) => (
+  <label className="block">
+    <span className="mb-1 block text-xs font-medium text-warm-olive">
+      {label}
+    </span>
+    <input
+      type={type}
+      min={type === "number" ? "0" : undefined}
+      inputMode={type === "number" ? "numeric" : undefined}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+    />
+  </label>
+);
+
+export default CommonExpenseItemsManagerModal;

--- a/src/components/pages/HistoryPage/CommonExpenseItemsPanel.js
+++ b/src/components/pages/HistoryPage/CommonExpenseItemsPanel.js
@@ -1,0 +1,175 @@
+import React, { useState } from "react";
+import { Plus, Settings } from "lucide-react";
+import CommonExpenseItemsManagerModal from "./CommonExpenseItemsManagerModal";
+
+const formatCurrency = (amount) => `$${amount.toLocaleString("zh-TW")}`;
+
+const blankItem = {
+  name: "",
+  vendor: "",
+  amount: "",
+};
+
+/**
+ * CommonExpenseItemsPanel
+ *
+ * 功能效果：設定常用原材料，並用大尺寸卡片快速帶入支出表單
+ * 使用範例：<CommonExpenseItemsPanel items={items} onSelectItem={fillForm} />
+ */
+const CommonExpenseItemsPanel = ({
+  items,
+  materialOptions,
+  vendorOptions,
+  onSelectItem,
+  onAddItem,
+  onUpdateItem,
+  onDeleteItem,
+}) => {
+  const [draftItem, setDraftItem] = useState(blankItem);
+  const [isManagerOpen, setIsManagerOpen] = useState(false);
+
+  const handleChange = (field, value) => {
+    setDraftItem((currentItem) => ({
+      ...currentItem,
+      [field]: value,
+    }));
+  };
+
+  const handleAddItem = (event) => {
+    event.preventDefault();
+
+    const amount = Number(draftItem.amount);
+    if (!draftItem.name.trim() || !draftItem.vendor.trim() || amount <= 0) {
+      window.alert("請填寫常用原材料名稱、廠商與大於 0 的價格");
+      return;
+    }
+
+    onAddItem({
+      name: draftItem.name.trim(),
+      vendor: draftItem.vendor.trim(),
+      amount,
+    });
+    setDraftItem(blankItem);
+  };
+
+  return (
+    <div className="bg-ivory rounded-lg p-4 shadow-whisper">
+      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-lg font-bold text-anthropic-black">常用原材料</h2>
+          <p className="text-sm text-warm-olive">
+            設定好名稱、廠商、價格後，點卡片即可帶入支出紀錄。
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsManagerOpen(true)}
+          className="inline-flex min-h-[40px] items-center justify-center gap-2 rounded-lg bg-parchment px-3 py-2 text-sm font-medium text-warm-charcoal transition-colors hover:bg-warm-sand"
+        >
+          <Settings className="h-4 w-4" />
+          管理常用清單
+          <span className="text-warm-stone">({items.length})</span>
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onSelectItem(item)}
+            className="min-h-[112px] rounded-lg border border-warm-cream bg-parchment p-4 text-left transition-colors hover:border-terracotta hover:bg-warm-sand focus:border-terracotta focus:outline-none"
+          >
+            <div className="line-clamp-2 font-bold text-anthropic-black">
+              {item.name}
+            </div>
+            <div className="mt-2 text-sm text-warm-olive">{item.vendor}</div>
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <span className="text-lg font-bold text-terracotta">
+                {formatCurrency(item.amount)}
+              </span>
+              <span className="text-xs text-warm-stone">點選帶入</span>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <form onSubmit={handleAddItem} className="mt-4 rounded-lg border border-warm-cream p-3">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="font-bold text-warm-charcoal">新增常用項目</h3>
+          <span className="text-xs text-warm-stone">v0 本機設定</span>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(280px,1fr)_220px_150px_auto]">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-warm-charcoal">名稱</span>
+            <input
+              type="text"
+              value={draftItem.name}
+              list="common-expense-material-options"
+              onChange={(event) => handleChange("name", event.target.value)}
+              placeholder="例：咖啡豆 耶加雪菲 水洗 1kg"
+              className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+            />
+            <datalist id="common-expense-material-options">
+              {materialOptions.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+          </label>
+
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-warm-charcoal">廠商</span>
+            <input
+              type="text"
+              value={draftItem.vendor}
+              list="common-expense-vendor-options"
+              onChange={(event) => handleChange("vendor", event.target.value)}
+              placeholder="例：材料行名稱"
+              className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+            />
+            <datalist id="common-expense-vendor-options">
+              {vendorOptions.map((vendor) => (
+                <option key={vendor} value={vendor} />
+              ))}
+            </datalist>
+          </label>
+
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-warm-charcoal">價格</span>
+            <input
+              type="number"
+              min="0"
+              inputMode="numeric"
+              value={draftItem.amount}
+              onChange={(event) => handleChange("amount", event.target.value)}
+              placeholder="0"
+              className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+            />
+          </label>
+
+          <div className="flex items-end">
+            <button
+              type="submit"
+              className="flex min-h-[42px] w-full items-center justify-center gap-2 rounded-lg bg-terracotta px-4 py-2 font-medium text-ivory transition-colors hover:bg-terracotta-dark xl:w-auto"
+            >
+              <Plus className="h-4 w-4" />
+              新增常用
+            </button>
+          </div>
+        </div>
+      </form>
+
+      {isManagerOpen && (
+        <CommonExpenseItemsManagerModal
+          items={items}
+          onClose={() => setIsManagerOpen(false)}
+          onUpdateItem={onUpdateItem}
+          onDeleteItem={onDeleteItem}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CommonExpenseItemsPanel;

--- a/src/components/pages/HistoryPage/DateSelector.js
+++ b/src/components/pages/HistoryPage/DateSelector.js
@@ -15,22 +15,23 @@ const DateSelector = ({
   displayMode,
   onDisplayModeChange,
   dateRangeText,
+  showDisplayModeControls = true,
 }) => {
   return (
     <div className="bg-ivory rounded-lg p-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
-          <label className="font-medium">查看日期:</label>
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <label className="font-medium whitespace-nowrap">查看日期:</label>
           <input
             type="date"
             value={selectedDate}
             onChange={(e) => onDateChange(e.target.value)}
-            className="border rounded-lg px-3 py-2"
+            className="w-full border rounded-lg px-3 py-2 sm:w-auto"
           />
           <div className="text-sm text-warm-olive">期間: {dateRangeText}</div>
         </div>
-        <div className="flex space-x-2">
-          {viewMode === "daily" && (
+        <div className="flex flex-wrap gap-2">
+          {showDisplayModeControls && viewMode === "daily" && (
             <div className="flex bg-parchment rounded-lg p-1">
               <button
                 onClick={() => onDisplayModeChange("grouped")}

--- a/src/components/pages/HistoryPage/ExpenseRecordsPage.js
+++ b/src/components/pages/HistoryPage/ExpenseRecordsPage.js
@@ -1,0 +1,274 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import CommonExpenseItemsPanel from "./CommonExpenseItemsPanel";
+import VendorFilterChips from "./VendorFilterChips";
+
+const formatCurrency = (amount) => `$${amount.toLocaleString("zh-TW")}`;
+
+const initialFormState = {
+  date: "",
+  name: "",
+  vendor: "",
+  amount: "",
+};
+
+/**
+ * ExpenseRecordsPage
+ *
+ * 功能效果：v0 支出紀錄頁，只紀錄日期、名稱、廠商、金額與本期總額
+ * 使用範例：<ExpenseRecordsPage expenseRecords={records} onAddRecord={addRecord} />
+ */
+const ExpenseRecordsPage = ({
+  selectedDate,
+  dateRangeText,
+  expenseRecords,
+  vendorOptions,
+  materialOptions,
+  commonVendorOptions,
+  commonExpenseItems,
+  onAddRecord,
+  onDeleteRecord,
+  onAddCommonItem,
+  onUpdateCommonItem,
+  onDeleteCommonItem,
+}) => {
+  const [activeVendor, setActiveVendor] = useState("all");
+  const [formData, setFormData] = useState({
+    ...initialFormState,
+    date: selectedDate,
+  });
+
+  useEffect(() => {
+    setFormData((currentData) => ({
+      ...currentData,
+      date: selectedDate,
+    }));
+  }, [selectedDate]);
+
+  useEffect(() => {
+    if (activeVendor !== "all" && !vendorOptions.includes(activeVendor)) {
+      setActiveVendor("all");
+    }
+  }, [activeVendor, vendorOptions]);
+
+  const visibleExpenseRecords = useMemo(() => {
+    if (activeVendor === "all") return expenseRecords;
+    return expenseRecords.filter((record) => record.vendor === activeVendor);
+  }, [activeVendor, expenseRecords]);
+
+  const visibleExpenseTotal = visibleExpenseRecords.reduce(
+    (sum, record) => sum + record.amount,
+    0,
+  );
+
+  const handleChange = (field, value) => {
+    setFormData((currentData) => ({
+      ...currentData,
+      [field]: value,
+    }));
+  };
+
+  const handleSelectCommonItem = (item) => {
+    setFormData({
+      date: selectedDate,
+      name: item.name,
+      vendor: item.vendor,
+      amount: String(item.amount),
+    });
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const amount = Number(formData.amount);
+    if (!formData.date || !formData.name.trim() || !formData.vendor.trim() || amount <= 0) {
+      window.alert("請填寫日期、名稱、廠商與大於 0 的金額");
+      return;
+    }
+
+    onAddRecord({
+      date: formData.date,
+      name: formData.name.trim(),
+      vendor: formData.vendor.trim(),
+      amount,
+    });
+
+    setFormData({
+      ...initialFormState,
+      date: formData.date,
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <CommonExpenseItemsPanel
+        items={commonExpenseItems}
+        materialOptions={materialOptions}
+        vendorOptions={commonVendorOptions}
+        onSelectItem={handleSelectCommonItem}
+        onAddItem={onAddCommonItem}
+        onUpdateItem={onUpdateCommonItem}
+        onDeleteItem={onDeleteCommonItem}
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <form onSubmit={handleSubmit} className="bg-ivory rounded-lg p-4 shadow-whisper">
+          <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-anthropic-black">新增支出紀錄</h2>
+              <p className="text-sm text-warm-olive">
+                點選常用原材料會自動帶入，仍可手動微調。
+              </p>
+            </div>
+            <div className="text-sm text-warm-stone">期間: {dateRangeText}</div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 xl:grid-cols-[150px_minmax(280px,1fr)_220px_150px_auto]">
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium text-warm-charcoal">日期</span>
+              <input
+                type="date"
+                value={formData.date}
+                onChange={(event) => handleChange("date", event.target.value)}
+                className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+              />
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium text-warm-charcoal">名稱</span>
+              <input
+                type="text"
+                value={formData.name}
+                list="expense-material-options"
+                onChange={(event) => handleChange("name", event.target.value)}
+                placeholder="例：咖啡豆 耶加雪菲 水洗 1kg"
+                className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+              />
+              <datalist id="expense-material-options">
+                {materialOptions.map((name) => (
+                  <option key={name} value={name} />
+                ))}
+              </datalist>
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium text-warm-charcoal">廠商</span>
+              <input
+                type="text"
+                value={formData.vendor}
+                list="expense-vendor-options"
+                onChange={(event) => handleChange("vendor", event.target.value)}
+                placeholder="例：材料行名稱"
+                className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+              />
+              <datalist id="expense-vendor-options">
+                {vendorOptions.map((vendor) => (
+                  <option key={vendor} value={vendor} />
+                ))}
+              </datalist>
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium text-warm-charcoal">金額</span>
+              <input
+                type="number"
+                min="0"
+                inputMode="numeric"
+                value={formData.amount}
+                onChange={(event) => handleChange("amount", event.target.value)}
+                placeholder="0"
+                className="w-full rounded-lg border border-warm-sand bg-ivory px-3 py-2 focus:border-terracotta focus:outline-none"
+              />
+            </label>
+
+            <div className="flex items-end">
+              <button
+                type="submit"
+                className="flex min-h-[42px] w-full items-center justify-center gap-2 rounded-lg bg-terracotta px-4 py-2 font-medium text-ivory transition-colors hover:bg-terracotta-dark xl:w-auto"
+              >
+                <Plus className="h-4 w-4" />
+                新增
+              </button>
+            </div>
+          </div>
+        </form>
+
+        <div className="bg-ivory rounded-lg p-4 shadow-whisper">
+          <div className="text-sm text-warm-olive">
+            {activeVendor === "all" ? "本期支出總額" : `${activeVendor} 支出總額`}
+          </div>
+          <div className="mt-2 text-3xl font-bold text-error-warm">
+            {formatCurrency(visibleExpenseTotal)}
+          </div>
+          <div className="mt-1 text-sm text-warm-stone">
+            共 {visibleExpenseRecords.length} 筆支出紀錄
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-ivory rounded-lg p-4 shadow-whisper">
+        <div className="mb-3 flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-anthropic-black">支出紀錄</h2>
+            <span className="text-sm text-warm-olive">{dateRangeText}</span>
+          </div>
+          <VendorFilterChips
+            vendors={vendorOptions}
+            activeVendor={activeVendor}
+            onVendorChange={setActiveVendor}
+          />
+        </div>
+
+        {visibleExpenseRecords.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-warm-sand py-10 text-center text-warm-stone">
+            這個期間尚無支出紀錄
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[760px] border-separate border-spacing-0 text-sm">
+              <thead>
+                <tr className="text-left text-warm-olive">
+                  <th className="border-b border-warm-cream px-3 py-3 font-medium">日期</th>
+                  <th className="border-b border-warm-cream px-3 py-3 font-medium">名稱</th>
+                  <th className="border-b border-warm-cream px-3 py-3 font-medium">廠商</th>
+                  <th className="border-b border-warm-cream px-3 py-3 text-right font-medium">金額</th>
+                  <th className="border-b border-warm-cream px-3 py-3 text-right font-medium">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleExpenseRecords.map((record) => (
+                  <tr key={record.id} className="hover:bg-parchment">
+                    <td className="border-b border-warm-cream px-3 py-3 text-warm-charcoal">
+                      {record.date}
+                    </td>
+                    <td className="max-w-[420px] border-b border-warm-cream px-3 py-3 font-medium text-anthropic-black">
+                      {record.name}
+                    </td>
+                    <td className="border-b border-warm-cream px-3 py-3 text-warm-charcoal">
+                      {record.vendor}
+                    </td>
+                    <td className="border-b border-warm-cream px-3 py-3 text-right font-bold text-error-warm">
+                      {formatCurrency(record.amount)}
+                    </td>
+                    <td className="border-b border-warm-cream px-3 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => onDeleteRecord(record.id)}
+                        className="inline-flex min-h-[34px] items-center gap-1 rounded-lg px-2 py-1 text-sm text-error-warm transition-colors hover:bg-error-warm/10"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        刪除
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ExpenseRecordsPage;

--- a/src/components/pages/HistoryPage/FinancialTabs.js
+++ b/src/components/pages/HistoryPage/FinancialTabs.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { ChartNoAxesColumn, ClipboardList, WalletCards } from "lucide-react";
+
+const tabs = [
+  { id: "income", label: "收入", icon: ChartNoAxesColumn },
+  { id: "expense", label: "支出", icon: ClipboardList },
+  { id: "overview", label: "收支總覽", icon: WalletCards },
+];
+
+/**
+ * FinancialTabs
+ *
+ * 功能效果：營業紀錄頁的收入、支出、收支總覽切換列
+ * 使用範例：<FinancialTabs activeTab="income" onTabChange={setActiveTab} />
+ */
+const FinancialTabs = ({ activeTab, onTabChange }) => {
+  return (
+    <div className="bg-ivory rounded-lg p-2 shadow-whisper">
+      <div className="grid grid-cols-3 gap-2">
+        {tabs.map(({ id, label, icon: Icon }) => {
+          const isActive = activeTab === id;
+
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onTabChange(id)}
+              className={`flex min-h-[44px] items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                isActive
+                  ? "bg-terracotta text-ivory shadow-whisper"
+                  : "text-warm-olive hover:bg-parchment hover:text-warm-charcoal"
+              }`}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="whitespace-nowrap">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default FinancialTabs;

--- a/src/components/pages/HistoryPage/ProfitOverviewPage.js
+++ b/src/components/pages/HistoryPage/ProfitOverviewPage.js
@@ -1,0 +1,165 @@
+import React from "react";
+
+const formatCurrency = (amount) => `$${amount.toLocaleString("zh-TW")}`;
+
+/**
+ * ProfitOverviewPage
+ *
+ * 功能效果：v0 收支總覽，用營收扣除採買支出顯示粗估結餘
+ * 使用範例：<ProfitOverviewPage incomeTotal={1000} expenseTotal={300} />
+ */
+const ProfitOverviewPage = ({
+  incomeTotal,
+  expenseTotal,
+  orderCount,
+  expenseCount,
+  dateRangeText,
+}) => {
+  const balance = incomeTotal - expenseTotal;
+  const totalFlow = incomeTotal + expenseTotal;
+  const incomeShare = totalFlow > 0 ? Math.round((incomeTotal / totalFlow) * 100) : 0;
+  const expenseShare = totalFlow > 0 ? 100 - incomeShare : 0;
+  const incomeDegrees = totalFlow > 0 ? (incomeTotal / totalFlow) * 360 : 0;
+  const pieBackground =
+    totalFlow > 0
+      ? `conic-gradient(#c96442 0deg ${incomeDegrees}deg, #b53333 ${incomeDegrees}deg 360deg)`
+      : "#e8e6dc";
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <SummaryCard label="收入總額" value={formatCurrency(incomeTotal)} tone="income" />
+        <SummaryCard label="支出總額" value={formatCurrency(expenseTotal)} tone="expense" />
+        <SummaryCard
+          label="粗估結餘"
+          value={formatCurrency(balance)}
+          tone={balance >= 0 ? "income" : "expense"}
+        />
+      </div>
+
+      <div className="bg-ivory rounded-lg p-4 shadow-whisper">
+        <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-anthropic-black">收支總覽</h2>
+            <p className="text-sm text-warm-olive">
+              目前只扣除支出紀錄中的採買金額，尚未包含人事、租金、水電等成本。
+            </p>
+          </div>
+          <div className="text-sm text-warm-stone">期間: {dateRangeText}</div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+          <div className="rounded-lg bg-parchment p-5">
+            <div className="grid grid-cols-1 gap-5 xl:grid-cols-[280px_480px] xl:items-center xl:justify-center xl:gap-[184px]">
+              <div className="mx-auto flex h-[280px] w-[280px] items-center justify-center rounded-full bg-warm-sand p-5 shadow-warm-ring">
+                <div
+                  className="flex h-full w-full items-center justify-center rounded-full"
+                  style={{ background: pieBackground }}
+                  aria-label={`收入 ${incomeShare}%，支出 ${expenseShare}%`}
+                >
+                  <div className="flex h-[164px] w-[164px] flex-col items-center justify-center rounded-full bg-ivory text-center shadow-warm-ring">
+                    <div className="text-xs text-warm-olive">粗估結餘</div>
+                    <div
+                      className={`mt-1 text-2xl font-bold ${
+                        balance >= 0 ? "text-terracotta" : "text-error-warm"
+                      }`}
+                    >
+                      {formatCurrency(balance)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="mx-auto w-full max-w-[480px] space-y-3 xl:mx-0">
+                <OverviewMetric
+                  label="收入"
+                  amount={incomeTotal}
+                  count={orderCount}
+                  share={incomeShare}
+                  markerClassName="bg-terracotta"
+                  valueClassName="text-terracotta"
+                />
+                <OverviewMetric
+                  label="支出"
+                  amount={expenseTotal}
+                  count={expenseCount}
+                  share={expenseShare}
+                  markerClassName="bg-error-warm"
+                  valueClassName="text-error-warm"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-warm-cream bg-ivory p-5 shadow-warm-ring">
+            <h3 className="text-lg font-bold text-anthropic-black">總覽</h3>
+            <div className="mt-5 space-y-4 text-sm text-warm-charcoal">
+              <div className="flex items-center justify-between gap-4 rounded-lg bg-parchment px-4 py-3">
+                <span>收入總額</span>
+                <span className="text-lg font-bold text-terracotta">
+                  {formatCurrency(incomeTotal)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-4 rounded-lg bg-parchment px-4 py-3">
+                <span>支出總額</span>
+                <span className="text-lg font-bold text-error-warm">
+                  - {formatCurrency(expenseTotal)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-4 border-t border-warm-cream pt-4">
+                <span>粗估結餘</span>
+                <span
+                  className={`text-2xl font-bold ${
+                    balance >= 0 ? "text-terracotta" : "text-error-warm"
+                  }`}
+                >
+                  {formatCurrency(balance)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const OverviewMetric = ({
+  label,
+  amount,
+  count,
+  share,
+  markerClassName,
+  valueClassName,
+}) => {
+  return (
+    <div className="rounded-lg bg-ivory px-4 py-2.5 shadow-warm-ring">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className={`h-3 w-3 rounded-full ${markerClassName}`} />
+          <span className="font-bold text-anthropic-black">{label}</span>
+        </div>
+        <span className={`text-lg font-bold ${valueClassName}`}>{share}%</span>
+      </div>
+      <div className="mt-2 flex items-end justify-between gap-2 text-xs text-warm-olive">
+        <span>{count} 筆紀錄</span>
+        <span className={`text-base font-bold ${valueClassName}`}>
+          {formatCurrency(amount)}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const SummaryCard = ({ label, value, tone }) => {
+  const valueColor = tone === "expense" ? "text-error-warm" : "text-terracotta";
+
+  return (
+    <div className="bg-ivory rounded-lg p-4 text-center shadow-whisper">
+      <div className={`text-2xl font-bold ${valueColor}`}>{value}</div>
+      <div className="text-sm text-warm-olive">{label}</div>
+    </div>
+  );
+};
+
+export default ProfitOverviewPage;

--- a/src/components/pages/HistoryPage/VendorFilterChips.js
+++ b/src/components/pages/HistoryPage/VendorFilterChips.js
@@ -1,0 +1,42 @@
+import React from "react";
+
+/**
+ * VendorFilterChips
+ *
+ * 功能效果：用廠商標籤篩選目前日期區間內的支出紀錄
+ * 使用範例：<VendorFilterChips vendors={vendors} activeVendor="all" />
+ */
+const VendorFilterChips = ({ vendors, activeVendor, onVendorChange }) => {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => onVendorChange("all")}
+        className={`min-h-[34px] rounded-lg px-3 py-1 text-sm font-medium transition-colors ${
+          activeVendor === "all"
+            ? "bg-terracotta text-ivory"
+            : "bg-parchment text-warm-olive hover:bg-warm-sand"
+        }`}
+      >
+        全部廠商
+      </button>
+
+      {vendors.map((vendor) => (
+        <button
+          key={vendor}
+          type="button"
+          onClick={() => onVendorChange(vendor)}
+          className={`min-h-[34px] rounded-lg px-3 py-1 text-sm font-medium transition-colors ${
+            activeVendor === vendor
+              ? "bg-terracotta text-ivory"
+              : "bg-parchment text-warm-olive hover:bg-warm-sand"
+          }`}
+        >
+          {vendor}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default VendorFilterChips;

--- a/src/components/pages/HistoryPage/demoFinancialData.js
+++ b/src/components/pages/HistoryPage/demoFinancialData.js
@@ -1,0 +1,104 @@
+export const demoExpenseRecords = [
+  {
+    id: "expense-demo-1",
+    date: "2026-06-24",
+    name: "咖啡豆 耶加雪菲 水洗 1kg",
+    vendor: "Sagasu 咖啡材料行",
+    amount: 1200,
+  },
+  {
+    id: "expense-demo-2",
+    date: "2026-06-24",
+    name: "鮮奶",
+    vendor: "本地乳品商",
+    amount: 850,
+  },
+  {
+    id: "expense-demo-3",
+    date: "2026-06-18",
+    name: "外帶杯與杯蓋",
+    vendor: "包材供應商",
+    amount: 1680,
+  },
+];
+
+export const demoCommonExpenseItems = [
+  {
+    id: "common-expense-1",
+    name: "咖啡豆 耶加雪菲 水洗 1kg",
+    vendor: "Sagasu 咖啡材料行",
+    amount: 1200,
+  },
+  {
+    id: "common-expense-2",
+    name: "鮮奶",
+    vendor: "本地乳品商",
+    amount: 850,
+  },
+  {
+    id: "common-expense-3",
+    name: "外帶杯與杯蓋",
+    vendor: "包材供應商",
+    amount: 1680,
+  },
+];
+
+export const createDemoIncomeRecords = (selectedDate) => {
+  const baseTimestamp = new Date(`${selectedDate}T12:00:00+08:00`).getTime();
+
+  return [
+    {
+      id: "income-demo-1",
+      date: selectedDate,
+      time: "12:15",
+      timestamp: baseTimestamp,
+      table: "S1",
+      type: "table",
+      paymentMethod: "cash",
+      isRefunded: false,
+      isPartialPayment: false,
+      total: 1280,
+      itemCount: 7,
+      items: [
+        { name: "辣蛋沙拉堡", quantity: 3, price: 130, subtotal: 390 },
+        { name: "香草巴斯克", quantity: 2, price: 130, subtotal: 260 },
+        { name: "可麗露", quantity: 2, price: 315, subtotal: 630 },
+      ],
+    },
+    {
+      id: "income-demo-2",
+      date: selectedDate,
+      time: "14:30",
+      timestamp: baseTimestamp + 8100000,
+      table: "T1",
+      type: "takeout",
+      paymentMethod: "linepay",
+      isRefunded: false,
+      isPartialPayment: false,
+      total: 860,
+      itemCount: 5,
+      items: [
+        { name: "拿鐵", quantity: 3, price: 140, subtotal: 420 },
+        { name: "磅磅", quantity: 2, price: 220, subtotal: 440 },
+      ],
+    },
+    {
+      id: "income-demo-3",
+      date: selectedDate,
+      time: "16:05",
+      timestamp: baseTimestamp + 14700000,
+      table: "S3",
+      type: "table",
+      paymentMethod: "cash",
+      isRefunded: false,
+      isPartialPayment: false,
+      total: 1180,
+      itemCount: 6,
+      items: [
+        { name: "手沖咖啡", quantity: 2, price: 180, subtotal: 360 },
+        { name: "可麗露", quantity: 3, price: 100, subtotal: 300 },
+        { name: "香草巴斯克", quantity: 1, price: 520, subtotal: 520 },
+      ],
+    },
+  ];
+};


### PR DESCRIPTION
## 變更內容
- 在營業紀錄新增收入 / 支出 / 收支總覽分頁
- 新增支出紀錄 v0：日期、名稱、廠商、金額與本期總額
- 新增常用原材料清單，支援新增、點選帶入、搜尋、編輯與刪除
- 新增廠商篩選標籤
- 新增收支總覽圓餅圖與總覽卡片，並保留收入頁既有營業紀錄功能

## 驗證
- npx react-scripts build
- 本機瀏覽器驗證支出常用清單編輯、刪除與帶入流程
- 本機瀏覽器驗證收支總覽移除同桌訂單 / 詳細檢視切換
- 桌面、平板、手機尺寸確認無水平溢出

## 備註
- 這是 v0，本次支出與常用清單資料仍是本機 state / demo data，尚未接 Firebase 持久化