### PR TITLE
[codex] Persist expense records in Firebase

### DIFF
--- a/src/components/pages/HistoryPage.js
+++ b/src/components/pages/HistoryPage.js
@@ -1,13 +1,12 @@
 import React, { useMemo, useState } from "react";
 import Header from "../UI/Header";
 import useHistoryData from "../../hooks/useHistoryData";
+import useExpenseData from "../../hooks/useExpenseData";
 import {
   getDateRangeText,
   getDailyBreakdown,
-  getMonthRange,
   groupRecordsByTable,
   getPopularItems,
-  getWeekRange,
 } from "../../utils/historyUtils";
 
 import DateSelector from "./HistoryPage/DateSelector";
@@ -34,8 +33,6 @@ import RefundConfirmModal from "./HistoryPage/RefundConfirmModal";
  */
 const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
   const [activeFinancialTab, setActiveFinancialTab] = useState("income");
-  const [expenseRecords, setExpenseRecords] = useState([]);
-  const [commonExpenseItems, setCommonExpenseItems] = useState([]);
 
   const {
     salesHistory,
@@ -55,6 +52,18 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
     handleCancelRefund,
   } = useHistoryData({ onRefundOrder });
 
+  const {
+    expenseRecords,
+    commonExpenseItems,
+    expenseLoading,
+    expenseSaving,
+    handleAddExpenseRecord,
+    handleDeleteExpenseRecord,
+    handleAddCommonExpenseItem,
+    handleUpdateCommonExpenseItem,
+    handleDeleteCommonExpenseItem,
+  } = useExpenseData(selectedDate, viewMode);
+
   const allPeriodRecords = salesHistory;
   const activePeriodRecords = allPeriodRecords.filter((r) => !r.isRefunded);
   const refundedPeriodRecords = allPeriodRecords.filter((r) => r.isRefunded);
@@ -68,35 +77,14 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
   const dailyBreakdown = viewMode !== "daily" ? getDailyBreakdown(allPeriodRecords) : [];
   const dateRangeText = getDateRangeText(viewMode, selectedDate);
 
-  const filteredExpenseRecords = useMemo(() => {
-    let startDate = selectedDate;
-    let endDate = selectedDate;
-
-    if (viewMode === "weekly") {
-      const range = getWeekRange(selectedDate);
-      startDate = range.start;
-      endDate = range.end;
-    }
-
-    if (viewMode === "monthly") {
-      const range = getMonthRange(selectedDate);
-      startDate = range.start;
-      endDate = range.end;
-    }
-
-    return expenseRecords
-      .filter((record) => record.date >= startDate && record.date <= endDate)
-      .sort((a, b) => b.date.localeCompare(a.date));
-  }, [expenseRecords, selectedDate, viewMode]);
-
-  const periodExpenseTotal = filteredExpenseRecords.reduce(
+  const periodExpenseTotal = expenseRecords.reduce(
     (sum, record) => sum + record.amount,
     0,
   );
 
   const vendorOptions = useMemo(
-    () => [...new Set(filteredExpenseRecords.map((record) => record.vendor))],
-    [filteredExpenseRecords],
+    () => [...new Set(expenseRecords.map((record) => record.vendor))],
+    [expenseRecords],
   );
 
   const materialOptions = useMemo(
@@ -109,51 +97,11 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
     [commonExpenseItems],
   );
 
-  const handleAddExpenseRecord = (record) => {
-    setExpenseRecords((currentRecords) => [
-      {
-        ...record,
-        id: `expense-${Date.now()}`,
-      },
-      ...currentRecords,
-    ]);
-  };
-
-  const handleDeleteExpenseRecord = (recordId) => {
-    setExpenseRecords((currentRecords) =>
-      currentRecords.filter((record) => record.id !== recordId),
-    );
-  };
-
-  const handleAddCommonExpenseItem = (item) => {
-    setCommonExpenseItems((currentItems) => [
-      {
-        ...item,
-        id: `common-expense-${Date.now()}`,
-      },
-      ...currentItems,
-    ]);
-  };
-
-  const handleDeleteCommonExpenseItem = (itemId) => {
-    setCommonExpenseItems((currentItems) =>
-      currentItems.filter((item) => item.id !== itemId),
-    );
-  };
-
-  const handleUpdateCommonExpenseItem = (itemId, nextItem) => {
-    setCommonExpenseItems((currentItems) =>
-      currentItems.map((item) =>
-        item.id === itemId ? { ...item, ...nextItem } : item,
-      ),
-    );
-  };
-
   return (
     <div className="min-h-screen bg-parchment">
-      {loading && (
+      {(loading || expenseLoading || expenseSaving) && (
         <div className="fixed top-4 right-4 bg-terracotta text-ivory px-4 py-2 rounded shadow-lg z-50">
-          載入中...
+          資料同步中...
         </div>
       )}
 
@@ -235,11 +183,12 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
           <ExpenseRecordsPage
             selectedDate={selectedDate}
             dateRangeText={dateRangeText}
-            expenseRecords={filteredExpenseRecords}
+            expenseRecords={expenseRecords}
             vendorOptions={vendorOptions}
             materialOptions={materialOptions}
             commonVendorOptions={commonVendorOptions}
             commonExpenseItems={commonExpenseItems}
+            isSaving={expenseSaving}
             onAddRecord={handleAddExpenseRecord}
             onDeleteRecord={handleDeleteExpenseRecord}
             onAddCommonItem={handleAddCommonExpenseItem}
@@ -253,7 +202,7 @@ const HistoryPage = ({ onBack, onMenuSelect, onRefundOrder, onLogout }) => {
             incomeTotal={periodTotal}
             expenseTotal={periodExpenseTotal}
             orderCount={activePeriodRecords.length}
-            expenseCount={filteredExpenseRecords.length}
+            expenseCount={expenseRecords.length}
             dateRangeText={dateRangeText}
           />
         )}

--- a/src/components/pages/HistoryPage/CommonExpenseItemsManagerModal.js
+++ b/src/components/pages/HistoryPage/CommonExpenseItemsManagerModal.js
@@ -18,6 +18,7 @@ const blankItem = {
 const CommonExpenseItemsManagerModal = ({
   items,
   onClose,
+  isSaving = false,
   onUpdateItem,
   onDeleteItem,
 }) => {
@@ -55,19 +56,36 @@ const CommonExpenseItemsManagerModal = ({
     }));
   };
 
-  const handleSaveEditing = () => {
+  const handleSaveEditing = async () => {
     const amount = Number(editingDraft.amount);
     if (!editingDraft.name.trim() || !editingDraft.vendor.trim() || amount <= 0) {
       window.alert("請填寫常用原材料名稱、廠商與大於 0 的價格");
       return;
     }
 
-    onUpdateItem(editingItemId, {
-      name: editingDraft.name.trim(),
-      vendor: editingDraft.vendor.trim(),
-      amount,
-    });
-    cancelEditing();
+    try {
+      await onUpdateItem(editingItemId, {
+        name: editingDraft.name.trim(),
+        vendor: editingDraft.vendor.trim(),
+        amount,
+      });
+      cancelEditing();
+    } catch (error) {
+      console.error("更新常用原材料失敗:", error);
+      window.alert("更新常用原材料失敗，請檢查網路後再試");
+    }
+  };
+
+  const handleDeleteItem = async (itemId) => {
+    const confirmed = window.confirm("這個常用項目會從 Firebase 刪除，確定刪除嗎？");
+    if (!confirmed) return;
+
+    try {
+      await onDeleteItem(itemId);
+    } catch (error) {
+      console.error("刪除常用原材料失敗:", error);
+      window.alert("刪除常用原材料失敗，請檢查網路後再試");
+    }
   };
 
   return (
@@ -122,7 +140,8 @@ const CommonExpenseItemsManagerModal = ({
                   onCancelEditing={cancelEditing}
                   onEditingChange={handleEditingChange}
                   onSaveEditing={handleSaveEditing}
-                  onDeleteItem={onDeleteItem}
+                  onDeleteItem={handleDeleteItem}
+                  isSaving={isSaving}
                 />
               ))}
             </div>
@@ -133,6 +152,7 @@ const CommonExpenseItemsManagerModal = ({
           <button
             type="button"
             onClick={onClose}
+            disabled={isSaving}
             className="min-h-[40px] rounded-lg bg-terracotta px-4 py-2 font-medium text-ivory transition-colors hover:bg-terracotta-dark"
           >
             完成
@@ -152,6 +172,7 @@ const CommonExpenseItemRow = ({
   onEditingChange,
   onSaveEditing,
   onDeleteItem,
+  isSaving,
 }) => {
   return (
     <div className="rounded-lg border border-warm-cream bg-parchment p-3">
@@ -179,10 +200,11 @@ const CommonExpenseItemRow = ({
             <button
               type="button"
               onClick={onSaveEditing}
+              disabled={isSaving}
               className="inline-flex min-h-[42px] flex-1 items-center justify-center gap-2 rounded-lg bg-terracotta px-3 py-2 text-sm font-medium text-ivory transition-colors hover:bg-terracotta-dark lg:flex-none"
             >
               <Check className="h-4 w-4" />
-              儲存
+              {isSaving ? "儲存中" : "儲存"}
             </button>
             <button
               type="button"
@@ -213,6 +235,7 @@ const CommonExpenseItemRow = ({
             <button
               type="button"
               onClick={() => onDeleteItem(item.id)}
+              disabled={isSaving}
               className="inline-flex min-h-[38px] flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-error-warm transition-colors hover:bg-error-warm/10 sm:flex-none"
             >
               <Trash2 className="h-4 w-4" />

--- a/src/components/pages/HistoryPage/CommonExpenseItemsPanel.js
+++ b/src/components/pages/HistoryPage/CommonExpenseItemsPanel.js
@@ -21,6 +21,7 @@ const CommonExpenseItemsPanel = ({
   materialOptions,
   vendorOptions,
   onSelectItem,
+  isSaving = false,
   onAddItem,
   onUpdateItem,
   onDeleteItem,
@@ -35,7 +36,7 @@ const CommonExpenseItemsPanel = ({
     }));
   };
 
-  const handleAddItem = (event) => {
+  const handleAddItem = async (event) => {
     event.preventDefault();
 
     const amount = Number(draftItem.amount);
@@ -44,12 +45,17 @@ const CommonExpenseItemsPanel = ({
       return;
     }
 
-    onAddItem({
-      name: draftItem.name.trim(),
-      vendor: draftItem.vendor.trim(),
-      amount,
-    });
-    setDraftItem(blankItem);
+    try {
+      await onAddItem({
+        name: draftItem.name.trim(),
+        vendor: draftItem.vendor.trim(),
+        amount,
+      });
+      setDraftItem(blankItem);
+    } catch (error) {
+      console.error("新增常用原材料失敗:", error);
+      window.alert("新增常用原材料失敗，請檢查網路後再試");
+    }
   };
 
   return (
@@ -97,7 +103,7 @@ const CommonExpenseItemsPanel = ({
       <form onSubmit={handleAddItem} className="mt-4 rounded-lg border border-warm-cream p-3">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="font-bold text-warm-charcoal">新增常用項目</h3>
-          <span className="text-xs text-warm-stone">v0 本機設定</span>
+          <span className="text-xs text-warm-stone">Firebase 同步</span>
         </div>
 
         <div className="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(280px,1fr)_220px_150px_auto]">
@@ -151,10 +157,11 @@ const CommonExpenseItemsPanel = ({
           <div className="flex items-end">
             <button
               type="submit"
+              disabled={isSaving}
               className="flex min-h-[42px] w-full items-center justify-center gap-2 rounded-lg bg-terracotta px-4 py-2 font-medium text-ivory transition-colors hover:bg-terracotta-dark xl:w-auto"
             >
               <Plus className="h-4 w-4" />
-              新增常用
+              {isSaving ? "儲存中" : "新增常用"}
             </button>
           </div>
         </div>
@@ -164,6 +171,7 @@ const CommonExpenseItemsPanel = ({
         <CommonExpenseItemsManagerModal
           items={items}
           onClose={() => setIsManagerOpen(false)}
+          isSaving={isSaving}
           onUpdateItem={onUpdateItem}
           onDeleteItem={onDeleteItem}
         />

--- a/src/components/pages/HistoryPage/ExpenseRecordsPage.js
+++ b/src/components/pages/HistoryPage/ExpenseRecordsPage.js
@@ -26,6 +26,7 @@ const ExpenseRecordsPage = ({
   materialOptions,
   commonVendorOptions,
   commonExpenseItems,
+  isSaving = false,
   onAddRecord,
   onDeleteRecord,
   onAddCommonItem,
@@ -77,7 +78,7 @@ const ExpenseRecordsPage = ({
     });
   };
 
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
 
     const amount = Number(formData.amount);
@@ -86,17 +87,34 @@ const ExpenseRecordsPage = ({
       return;
     }
 
-    onAddRecord({
-      date: formData.date,
-      name: formData.name.trim(),
-      vendor: formData.vendor.trim(),
-      amount,
-    });
+    try {
+      await onAddRecord({
+        date: formData.date,
+        name: formData.name.trim(),
+        vendor: formData.vendor.trim(),
+        amount,
+      });
 
-    setFormData({
-      ...initialFormState,
-      date: formData.date,
-    });
+      setFormData({
+        ...initialFormState,
+        date: formData.date,
+      });
+    } catch (error) {
+      console.error("新增支出紀錄失敗:", error);
+      window.alert("新增支出紀錄失敗，請檢查網路後再試");
+    }
+  };
+
+  const handleDeleteRecord = async (recordId) => {
+    const confirmed = window.confirm("這筆支出紀錄會從 Firebase 刪除，確定刪除嗎？");
+    if (!confirmed) return;
+
+    try {
+      await onDeleteRecord(recordId);
+    } catch (error) {
+      console.error("刪除支出紀錄失敗:", error);
+      window.alert("刪除支出紀錄失敗，請檢查網路後再試");
+    }
   };
 
   return (
@@ -106,6 +124,7 @@ const ExpenseRecordsPage = ({
         materialOptions={materialOptions}
         vendorOptions={commonVendorOptions}
         onSelectItem={handleSelectCommonItem}
+        isSaving={isSaving}
         onAddItem={onAddCommonItem}
         onUpdateItem={onUpdateCommonItem}
         onDeleteItem={onDeleteCommonItem}
@@ -184,10 +203,11 @@ const ExpenseRecordsPage = ({
             <div className="flex items-end">
               <button
                 type="submit"
+                disabled={isSaving}
                 className="flex min-h-[42px] w-full items-center justify-center gap-2 rounded-lg bg-terracotta px-4 py-2 font-medium text-ivory transition-colors hover:bg-terracotta-dark xl:w-auto"
               >
                 <Plus className="h-4 w-4" />
-                新增
+                {isSaving ? "儲存中" : "新增"}
               </button>
             </div>
           </div>
@@ -253,7 +273,8 @@ const ExpenseRecordsPage = ({
                     <td className="border-b border-warm-cream px-3 py-3 text-right">
                       <button
                         type="button"
-                        onClick={() => onDeleteRecord(record.id)}
+                        onClick={() => handleDeleteRecord(record.id)}
+                        disabled={isSaving}
                         className="inline-flex min-h-[34px] items-center gap-1 rounded-lg px-2 py-1 text-sm text-error-warm transition-colors hover:bg-error-warm/10"
                       >
                         <Trash2 className="h-4 w-4" />

--- a/src/firebase/expenses.js
+++ b/src/firebase/expenses.js
@@ -1,0 +1,183 @@
+/**
+ * 支出紀錄相關的 Firebase 操作模組
+ *
+ * 功能：
+ * - 新增 / 查詢 / 刪除支出紀錄
+ * - 新增 / 查詢 / 編輯 / 刪除常用原材料
+ *
+ * 用途：
+ * - HistoryPage 的支出頁與收支總覽
+ */
+
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+import { db } from "./config";
+
+const STORE_ID = "default_store";
+
+const expenseRecordsRef = () => collection(db, "stores", STORE_ID, "expenseRecords");
+const commonExpenseItemsRef = () =>
+  collection(db, "stores", STORE_ID, "commonExpenseItems");
+
+const normalizeExpenseRecord = (record) => ({
+  date: record.date,
+  name: record.name,
+  vendor: record.vendor,
+  amount: Number(record.amount) || 0,
+});
+
+const normalizeCommonItem = (item) => ({
+  name: item.name,
+  vendor: item.vendor,
+  amount: Number(item.amount) || 0,
+});
+
+/**
+ * 根據日期範圍查詢支出紀錄
+ * @param {string} startDate - 開始日期 (YYYY-MM-DD)
+ * @param {string} endDate - 結束日期 (YYYY-MM-DD)
+ * @returns {Array} 支出紀錄陣列
+ */
+export const getExpenseRecordsByDate = async (startDate, endDate) => {
+  try {
+    const expenseQuery = query(
+      expenseRecordsRef(),
+      where("date", ">=", startDate),
+      where("date", "<=", endDate),
+      orderBy("date", "desc"),
+    );
+    const expenseSnap = await getDocs(expenseQuery);
+
+    const records = [];
+    expenseSnap.forEach((expenseDoc) => {
+      records.push({ id: expenseDoc.id, ...expenseDoc.data() });
+    });
+
+    return records.sort((a, b) => {
+      if (a.date !== b.date) return b.date.localeCompare(a.date);
+      return (b.createdAt || "").localeCompare(a.createdAt || "");
+    });
+  } catch (error) {
+    console.error("取得支出紀錄失敗:", error);
+    throw error;
+  }
+};
+
+/**
+ * 新增支出紀錄
+ * @param {Object} record - 支出紀錄
+ * @returns {Object} 新增後的支出紀錄
+ */
+export const addExpenseRecord = async (record) => {
+  try {
+    const now = new Date().toISOString();
+    const docRef = doc(expenseRecordsRef());
+    const recordData = {
+      ...normalizeExpenseRecord(record),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await setDoc(docRef, recordData);
+    return { id: docRef.id, ...recordData };
+  } catch (error) {
+    console.error("新增支出紀錄失敗:", error);
+    throw error;
+  }
+};
+
+/**
+ * 刪除支出紀錄
+ * @param {string} recordId - 支出紀錄 ID
+ */
+export const deleteExpenseRecord = async (recordId) => {
+  try {
+    await deleteDoc(doc(db, "stores", STORE_ID, "expenseRecords", recordId));
+  } catch (error) {
+    console.error(`刪除支出紀錄 ${recordId} 失敗:`, error);
+    throw error;
+  }
+};
+
+/**
+ * 取得所有常用原材料
+ * @returns {Array} 常用原材料陣列
+ */
+export const getCommonExpenseItems = async () => {
+  try {
+    const commonQuery = query(commonExpenseItemsRef(), orderBy("createdAt", "desc"));
+    const commonSnap = await getDocs(commonQuery);
+
+    const items = [];
+    commonSnap.forEach((commonDoc) => {
+      items.push({ id: commonDoc.id, ...commonDoc.data() });
+    });
+
+    return items;
+  } catch (error) {
+    console.error("取得常用原材料失敗:", error);
+    throw error;
+  }
+};
+
+/**
+ * 新增常用原材料
+ * @param {Object} item - 常用原材料
+ * @returns {Object} 新增後的常用原材料
+ */
+export const addCommonExpenseItem = async (item) => {
+  try {
+    const now = new Date().toISOString();
+    const docRef = doc(commonExpenseItemsRef());
+    const itemData = {
+      ...normalizeCommonItem(item),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await setDoc(docRef, itemData);
+    return { id: docRef.id, ...itemData };
+  } catch (error) {
+    console.error("新增常用原材料失敗:", error);
+    throw error;
+  }
+};
+
+/**
+ * 更新常用原材料
+ * @param {string} itemId - 常用原材料 ID
+ * @param {Object} updates - 要更新的欄位
+ */
+export const updateCommonExpenseItem = async (itemId, updates) => {
+  try {
+    await updateDoc(doc(db, "stores", STORE_ID, "commonExpenseItems", itemId), {
+      ...normalizeCommonItem(updates),
+      updatedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error(`更新常用原材料 ${itemId} 失敗:`, error);
+    throw error;
+  }
+};
+
+/**
+ * 刪除常用原材料
+ * @param {string} itemId - 常用原材料 ID
+ */
+export const deleteCommonExpenseItem = async (itemId) => {
+  try {
+    await deleteDoc(doc(db, "stores", STORE_ID, "commonExpenseItems", itemId));
+  } catch (error) {
+    console.error(`刪除常用原材料 ${itemId} 失敗:`, error);
+    throw error;
+  }
+};

--- a/src/firebase/operations.js
+++ b/src/firebase/operations.js
@@ -17,3 +17,4 @@ export * from './tables';
 export * from './orders';
 export * from './sales';
 export * from './users';
+export * from './expenses';

--- a/src/hooks/useExpenseData.js
+++ b/src/hooks/useExpenseData.js
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  addCommonExpenseItem,
+  addExpenseRecord,
+  deleteCommonExpenseItem,
+  deleteExpenseRecord,
+  getCommonExpenseItems,
+  getExpenseRecordsByDate,
+  updateCommonExpenseItem,
+} from "../firebase/expenses";
+import { getMonthRange, getWeekRange } from "../utils/historyUtils";
+
+const getDateRange = (selectedDate, viewMode) => {
+  if (viewMode === "weekly") {
+    return getWeekRange(selectedDate);
+  }
+
+  if (viewMode === "monthly") {
+    return getMonthRange(selectedDate);
+  }
+
+  return {
+    start: selectedDate,
+    end: selectedDate,
+  };
+};
+
+/**
+ * useExpenseData Hook
+ *
+ * 功能效果：管理支出紀錄與常用原材料的 Firebase 讀寫
+ * 使用範例：const expenseData = useExpenseData(selectedDate, viewMode)
+ */
+const useExpenseData = (selectedDate, viewMode) => {
+  const [expenseRecords, setExpenseRecords] = useState([]);
+  const [commonExpenseItems, setCommonExpenseItems] = useState([]);
+  const [expenseLoading, setExpenseLoading] = useState(false);
+  const [expenseSaving, setExpenseSaving] = useState(false);
+
+  const fetchExpenseRecords = useCallback(async () => {
+    const range = getDateRange(selectedDate, viewMode);
+    setExpenseLoading(true);
+
+    try {
+      const records = await getExpenseRecordsByDate(range.start, range.end);
+      setExpenseRecords(records);
+    } catch (error) {
+      console.error("載入支出紀錄失敗:", error);
+      setExpenseRecords([]);
+      throw error;
+    } finally {
+      setExpenseLoading(false);
+    }
+  }, [selectedDate, viewMode]);
+
+  const fetchCommonExpenseItems = useCallback(async () => {
+    setExpenseLoading(true);
+
+    try {
+      const items = await getCommonExpenseItems();
+      setCommonExpenseItems(items);
+    } catch (error) {
+      console.error("載入常用原材料失敗:", error);
+      setCommonExpenseItems([]);
+      throw error;
+    } finally {
+      setExpenseLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchExpenseRecords().catch(() => {
+      window.alert("支出紀錄載入失敗，請檢查網路後再試");
+    });
+  }, [fetchExpenseRecords]);
+
+  useEffect(() => {
+    fetchCommonExpenseItems().catch(() => {
+      window.alert("常用原材料載入失敗，請檢查網路後再試");
+    });
+  }, [fetchCommonExpenseItems]);
+
+  const runSavingTask = async (task) => {
+    setExpenseSaving(true);
+    try {
+      await task();
+    } finally {
+      setExpenseSaving(false);
+    }
+  };
+
+  const handleAddExpenseRecord = async (record) => {
+    await runSavingTask(async () => {
+      await addExpenseRecord(record);
+      await fetchExpenseRecords();
+    });
+  };
+
+  const handleDeleteExpenseRecord = async (recordId) => {
+    await runSavingTask(async () => {
+      await deleteExpenseRecord(recordId);
+      await fetchExpenseRecords();
+    });
+  };
+
+  const handleAddCommonExpenseItem = async (item) => {
+    await runSavingTask(async () => {
+      await addCommonExpenseItem(item);
+      await fetchCommonExpenseItems();
+    });
+  };
+
+  const handleUpdateCommonExpenseItem = async (itemId, nextItem) => {
+    await runSavingTask(async () => {
+      await updateCommonExpenseItem(itemId, nextItem);
+      await fetchCommonExpenseItems();
+    });
+  };
+
+  const handleDeleteCommonExpenseItem = async (itemId) => {
+    await runSavingTask(async () => {
+      await deleteCommonExpenseItem(itemId);
+      await fetchCommonExpenseItems();
+    });
+  };
+
+  return {
+    expenseRecords,
+    commonExpenseItems,
+    expenseLoading,
+    expenseSaving,
+    handleAddExpenseRecord,
+    handleDeleteExpenseRecord,
+    handleAddCommonExpenseItem,
+    handleUpdateCommonExpenseItem,
+    handleDeleteCommonExpenseItem,
+  };
+};
+
+export default useExpenseData;


### PR DESCRIPTION
﻿## Summary
- Persist expense records in Firestore under `stores/default_store/expenseRecords`
- Persist common expense items in Firestore under `stores/default_store/commonExpenseItems`
- Replace the HistoryPage local-only expense state with a Firebase-backed hook
- Wait for Firebase writes before clearing forms, and confirm destructive deletes

## Why
The expense record v0 was using local React state, so records and common items disappeared after refresh and did not match the app's Firebase-first behavior. This makes the new expense workflow durable and prevents local test data from being treated as real app data.

## Validation
- `$env:CI='false'; npx react-scripts build`
- Headless Chrome smoke test on localhost: opened the expense page with no runtime errors
- Verified expense record add/delete against Firebase, then confirmed the page returned to 0 records
- Verified common expense item add/edit/delete against Firebase, then confirmed the list returned to 0 items
- Checked tablet and mobile widths for no page-level horizontal overflow
- Confirmed no `CodexTest` or demo data remains in `src`
