### PR TITLE
fix: delete details in monthly financial archive job

### DIFF
--- a/functions/financialArchive/index.js
+++ b/functions/financialArchive/index.js
@@ -181,7 +181,7 @@ const monthlyFinancialArchive = onSchedule(
     archiveOldestEligibleMonthCore({
       retentionMonths: DEFAULT_RETENTION_MONTHS,
       dryRun: false,
-      deleteAfterArchive: false,
+      deleteAfterArchive: true,
     }),
 );
 


### PR DESCRIPTION
## Summary
- make the monthly financial archive job delete archived detail records after successful backup and summary writes
- prevents old income/expense detail rows from remaining visible after the retention window

## Verification
- node --check functions/financialArchive/index.js
- production archive/delete manually completed for 2025-09, 2025-10, and 2025-11
- production dry-run now reports no eligible month found