### PR TITLE
fix: restore yearly financial retention automation

### DIFF
--- a/functions/financialArchive/dateUtils.js
+++ b/functions/financialArchive/dateUtils.js
@@ -1,4 +1,4 @@
-const DEFAULT_RETENTION_MONTHS = 6;
+const DEFAULT_RETENTION_MONTHS = 12;
 
 const pad2 = (value) => String(value).padStart(2, "0");
 

--- a/functions/financialArchive/index.js
+++ b/functions/financialArchive/index.js
@@ -118,7 +118,7 @@ const archiveFinancialMonthCore = async ({
   }
 };
 
-const findOldestUnarchivedMonth = async (retentionMonths) => {
+const findOldestUnarchivedMonth = async (retentionMonths, { deleteAfterArchive = false } = {}) => {
   const latestEligibleMonth = getLatestEligibleMonth(retentionMonths);
   const { endDate } = getMonthRange(latestEligibleMonth);
   const [oldestSalesDate, oldestExpenseDate] = await Promise.all([
@@ -130,7 +130,8 @@ const findOldestUnarchivedMonth = async (retentionMonths) => {
 
   for (const candidateMonth of listMonths(oldestDate.slice(0, 7), latestEligibleMonth)) {
     const status = await getArchiveJobStatus(candidateMonth);
-    if (!["archived", "deleted"].includes(status)) return candidateMonth;
+    const completedStatuses = deleteAfterArchive ? ["deleted"] : ["archived", "deleted"];
+    if (!completedStatuses.includes(status)) return candidateMonth;
   }
 
   return null;
@@ -142,7 +143,7 @@ const archiveOldestEligibleMonthCore = async ({
   deleteAfterArchive = false,
 } = {}) => {
   const safeRetentionMonths = Math.max(1, Number(retentionMonths) || DEFAULT_RETENTION_MONTHS);
-  const month = await findOldestUnarchivedMonth(safeRetentionMonths);
+  const month = await findOldestUnarchivedMonth(safeRetentionMonths, { deleteAfterArchive });
 
   if (!month) {
     return {
@@ -159,6 +160,40 @@ const archiveOldestEligibleMonthCore = async ({
     dryRun,
     deleteAfterArchive,
   });
+};
+
+const archiveAllEligibleMonthsCore = async ({
+  retentionMonths = DEFAULT_RETENTION_MONTHS,
+  dryRun = false,
+  deleteAfterArchive = false,
+} = {}) => {
+  const safeRetentionMonths = Math.max(1, Number(retentionMonths) || DEFAULT_RETENTION_MONTHS);
+  const processed = [];
+
+  while (true) {
+    const month = await findOldestUnarchivedMonth(safeRetentionMonths, { deleteAfterArchive });
+    if (!month) break;
+
+    const result = await archiveFinancialMonthCore({
+      month,
+      retentionMonths: safeRetentionMonths,
+      dryRun,
+      deleteAfterArchive,
+    });
+    processed.push(result);
+
+    if (dryRun) break;
+  }
+
+  return {
+    success: true,
+    skipped: processed.length === 0,
+    reason: processed.length === 0 ? "No eligible month found" : undefined,
+    retentionMonths: safeRetentionMonths,
+    processedCount: processed.length,
+    processedMonths: processed.map((result) => result.month),
+    results: processed,
+  };
 };
 
 const archiveFinancialMonth = onCall(async (request) => {
@@ -178,7 +213,7 @@ const monthlyFinancialArchive = onSchedule(
     timeZone: "Asia/Taipei",
   },
   async () =>
-    archiveOldestEligibleMonthCore({
+    archiveAllEligibleMonthsCore({
       retentionMonths: DEFAULT_RETENTION_MONTHS,
       dryRun: false,
       deleteAfterArchive: true,
@@ -190,4 +225,5 @@ module.exports = {
   monthlyFinancialArchive,
   archiveFinancialMonthCore,
   archiveOldestEligibleMonthCore,
+  archiveAllEligibleMonthsCore,
 };

--- a/functions/scripts/validateFinancialArchive.js
+++ b/functions/scripts/validateFinancialArchive.js
@@ -13,7 +13,7 @@ const parseArgs = (argv) => {
   const options = {
     projectId: DEFAULT_PROJECT_ID,
     storageBucket: null,
-    retentionMonths: 6,
+    retentionMonths: 12,
     dryRun: true,
     deleteAfterArchive: false,
     force: false,
@@ -81,7 +81,7 @@ Options:
   --bucket <name>                        Storage bucket. Default: <projectId>-financial-archives
   --month <YYYY-MM>                      Validate one month.
   --oldest                               Validate the oldest eligible month.
-  --retention-months <number>            Default: 6
+  --retention-months <number>            Default: 12
   --force                                Allow a month inside the retention window for dev testing.
   --archive                              Actually upload files and write Firestore summaries.
   --delete-after-archive                 Delete Firestore details after archive verification.


### PR DESCRIPTION
## Summary
- restore production financial detail retention from 6 months to 12 months
- make the scheduled archive job process every eligible month in one run
- when deletion is enabled, treat only deleted jobs as complete so previously archived-only months can be cleaned up automatically

## Verification
- node --check functions/financialArchive/index.js
- node --check functions/financialArchive/dateUtils.js
- node --check functions/scripts/validateFinancialArchive.js
- production data restored for 2025-09 through 2025-11 from archive backups
- production 12-month dry-run reports no eligible month found